### PR TITLE
Fix no_auth user creation

### DIFF
--- a/api/uisvc/test/basic_test.go
+++ b/api/uisvc/test/basic_test.go
@@ -260,3 +260,14 @@ func (us *uisvcSuite) TestVisibility(c *check.C) {
 		c.Assert(repo.Name, check.Not(check.Equals), "not-erikh/private-test")
 	}
 }
+
+func (us *uisvcSuite) TestNoAuthUserCreation(c *check.C) {
+	client := github.NewMockClient(gomock.NewController(c))
+	_, doneChan, _, err := testservers.MakeUIServer(client)
+	c.Assert(err, check.IsNil)
+	defer close(doneChan)
+
+	u, err := us.datasvcClient.Client().GetUser("erikh")
+	c.Assert(err, check.IsNil)
+	c.Assert(u.Username, check.Equals, "erikh")
+}

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -106,6 +106,14 @@ func Boot(t *transport.HTTP, handler *H) (chan struct{}, *errors.Error) {
 		if err != nil {
 			return nil, err
 		}
+
+		_, err = handler.Clients.Data.GetUser(handler.DefaultUsername)
+		if err != nil {
+			handler.Clients.Log.Infof("Creating no_auth user account for %q", handler.DefaultUsername)
+			if _, err := handler.Clients.Data.PutUser(&model.User{Username: handler.DefaultUsername, Token: &oauth2.Token{AccessToken: handler.Auth.GithubToken}}); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	if t == nil {
@@ -257,7 +265,6 @@ func (h *H) configureSessions(r *gin.Engine) *errors.Error {
 }
 
 func (h *H) configureRestHandler(r *gin.Engine, key string, route *Route, optionsRoutes map[string]struct{}) {
-
 	var dispatchFunc func(string, ...gin.HandlerFunc) gin.IRoutes
 
 	switch route.Method {

--- a/testutil/testservers/servers.go
+++ b/testutil/testservers/servers.go
@@ -22,7 +22,6 @@ import (
 	"github.com/tinyci/ci-agents/grpc/services/queue"
 	"github.com/tinyci/ci-agents/handlers"
 	mockGithub "github.com/tinyci/ci-agents/mocks/github"
-	"github.com/tinyci/ci-agents/model"
 	"github.com/tinyci/ci-agents/testutil"
 	"google.golang.org/grpc"
 )
@@ -65,20 +64,16 @@ func MakeUIServer(client github.Client) (*handlers.H, chan struct{}, *tinyci.Cli
 		return nil, nil, nil, errors.New(err)
 	}
 
-	if _, err := d.PutUser(&model.User{Username: "erikh", Token: testutil.DummyToken}); err != nil {
-		return nil, nil, nil, err
-	}
-
-	token, eErr := d.GetToken("erikh")
-	if eErr != nil {
-		return nil, nil, nil, eErr
-	}
-
 	config.DefaultGithubClient = client
 	client.(*mockGithub.MockClient).EXPECT().MyLogin().Return("erikh", nil)
 	doneChan, err := handlers.Boot(nil, h)
 	if err != nil {
 		return nil, nil, nil, errors.New(err)
+	}
+
+	token, eErr := d.GetToken("erikh")
+	if eErr != nil {
+		return nil, nil, nil, eErr
 	}
 
 	tc, err := tinyci.New("http://localhost:6010", token)


### PR DESCRIPTION
Currently, there was an assumption in the tests that allowed servers to
never create the no_auth user based on its token value. This would allow
the services to boot, but have no legitimate user information to use.

This fixes it and removes a hack in the test that obscured the bug. yay.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>