### PR TITLE
Fix tokens in no_auth mode

### DIFF
--- a/api/uisvc/processors/token.go
+++ b/api/uisvc/processors/token.go
@@ -9,6 +9,10 @@ import (
 // GetToken obtains a new token from the db. If one is already set, you must
 // delete it before this will return a new one.
 func GetToken(h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+	if h.Auth.NoAuth && !h.Auth.TestMode {
+		return nil, 500, errors.New("cannot retrieve tokens in no_auth mode")
+	}
+
 	u, err := getUser(h, ctx)
 	if err != nil {
 		return nil, 500, err
@@ -24,6 +28,10 @@ func GetToken(h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error)
 
 // DeleteToken removes the existing token for the user.
 func DeleteToken(h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+	if h.Auth.NoAuth && !h.Auth.TestMode {
+		return nil, 500, errors.New("cannot manipulate tokens in no_auth mode")
+	}
+
 	u, err := getUser(h, ctx)
 	if err != nil {
 		return nil, 500, err

--- a/api/uisvc/test/basic_test.go
+++ b/api/uisvc/test/basic_test.go
@@ -49,8 +49,28 @@ func (us *uisvcSuite) TestLogAttach(c *check.C) {
 	pw.Close()
 	<-finished
 	c.Assert(strings.HasPrefix(buf.String(), "this is a log"), check.Equals, true)
+}
 
-	// XXX LogAttach does not error on missing ids -- https://github.com/tinyci/ci-agents/issues/270
+func (us *uisvcSuite) TestTestModeTokens(c *check.C) {
+	client := github.NewMockClient(gomock.NewController(c))
+	h, doneChan, tc, err := testservers.MakeUIServer(client)
+	c.Assert(err, check.IsNil)
+	defer close(doneChan)
+
+	h.Auth.TestMode = false
+
+	c.Assert(tc.DeleteToken(), check.ErrorMatches, "cannot manipulate tokens.*")
+}
+
+func (us *uisvcSuite) TestTokenEndpoints(c *check.C) {
+	client := github.NewMockClient(gomock.NewController(c))
+	_, doneChan, tc, err := testservers.MakeUIServer(client)
+	c.Assert(err, check.IsNil)
+	defer close(doneChan)
+
+	c.Assert(tc.DeleteToken(), check.IsNil)
+	_, err = tc.Errors()
+	c.Assert(err, check.ErrorMatches, ".*invalid authentication")
 }
 
 func (us *uisvcSuite) TestDeleteToken(c *check.C) {

--- a/config/auth.go
+++ b/config/auth.go
@@ -61,6 +61,7 @@ type AuthConfig struct {
 	GithubToken     string `yaml:"github_token"`
 	SessionCryptKey string `yaml:"session_crypt_key"`
 	TokenCryptKey   string `yaml:"token_crypt_key"`
+	TestMode        bool   `yaml:"-"` // test mode allows token auth in no_auth situations. Shouldn't be usable for real installs.
 
 	sessionCryptKey []byte
 	tokenCryptKey   []byte

--- a/testutil/testservers/servers.go
+++ b/testutil/testservers/servers.go
@@ -46,6 +46,7 @@ func MakeUIServer(client github.Client) (*handlers.H, chan struct{}, *tinyci.Cli
 			ClientConfig: clients,
 			URL:          "http://localhost",
 			Auth: config.AuthConfig{
+				TestMode:        true,
 				NoAuth:          true,
 				GithubToken:     "dummy",
 				SessionCryptKey: "0431d583a48a00243cc3d3d596ed362d77c50be4848dbf0d2f52bab841f072f9",


### PR DESCRIPTION
closes #30

This resolves a loophole in no_auth mode where tokens could be retrieved
and deleted by anyone.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>