### PR TITLE
Parameterize the assetsvc logs path

### DIFF
--- a/.config/services.yaml.example
+++ b/.config/services.yaml.example
@@ -22,6 +22,7 @@ clients:
   uisvc: 'http://localhost:6010' # uisvc uses http, so urls.
 services:
   last_scanned_wait: 1h
+  logs_root_path: /var/tinyci/logs # default, will need to change if non-root or set perms beforehand
 websockets:
   insecure_websockets: true
 db: 'host=localhost database=tinyci user=tinyci password=tinyci'

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -65,7 +65,7 @@ func serve(ctx *cli.Context) error {
 	}
 
 	s := grpc.NewServer()
-	asset.RegisterAssetServer(s, &processors.AssetServer{})
+	asset.RegisterAssetServer(s, &processors.AssetServer{H: h})
 
 	doneChan, err := h.Boot(t, s)
 	if err != nil {

--- a/testutil/testservers/servers.go
+++ b/testutil/testservers/servers.go
@@ -165,7 +165,7 @@ func MakeAssetServer() (*handler.H, chan struct{}, *errors.Error) {
 	}
 
 	srv := grpc.NewServer()
-	asset.RegisterAssetServer(srv, &assetsvc.AssetServer{})
+	asset.RegisterAssetServer(srv, &assetsvc.AssetServer{H: h})
 
 	doneChan, err := h.Boot(t, srv)
 	return h, doneChan, errors.New(err)


### PR DESCRIPTION
This is an artifact of an earlier era. This parameter is now tweakable
via the `logs_root_path` parameter of the `services` settings.

closes #46 

Signed-off-by: Erik Hollensbe <github@hollensbe.org>