### PR TITLE
Retry logic for GRPC

### DIFF
--- a/api/datasvc/processors/errors.go
+++ b/api/datasvc/processors/errors.go
@@ -7,13 +7,14 @@ import (
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/grpc/types"
+	"google.golang.org/grpc/codes"
 )
 
 // GetErrors retrieves the errors for the provided user.
 func (ds *DataServer) GetErrors(ctx context.Context, name *data.Name) (*types.UserErrors, error) {
 	u, err := ds.H.Model.FindUserByName(name.Name)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	errors := &types.UserErrors{}
@@ -28,13 +29,13 @@ func (ds *DataServer) GetErrors(ctx context.Context, name *data.Name) (*types.Us
 func (ds *DataServer) AddError(ctx context.Context, ue *types.UserError) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByID(ue.UserID)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	u.AddError(errors.New(ue.Error))
 
 	if err := ds.H.Model.Save(u).Error; err != nil {
-		return nil, errors.New(err)
+		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -42,13 +43,13 @@ func (ds *DataServer) AddError(ctx context.Context, ue *types.UserError) (*empty
 
 // DeleteError removes an error from errors list. The error string does not need to be provided.
 func (ds *DataServer) DeleteError(ctx context.Context, ue *types.UserError) (*empty.Empty, error) {
-	u, eErr := ds.H.Model.FindUserByID(ue.UserID)
-	if eErr != nil {
-		return nil, eErr
+	u, err := ds.H.Model.FindUserByID(ue.UserID)
+	if err != nil {
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.DeleteError(u, ue.Id); err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil

--- a/api/datasvc/processors/oauth.go
+++ b/api/datasvc/processors/oauth.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/tinyci/ci-agents/grpc/services/data"
+	"google.golang.org/grpc/codes"
 )
 
 // OAuthRegisterState registers the state code with the datasvc; it will be
@@ -12,7 +13,7 @@ import (
 // to us.
 func (ds *DataServer) OAuthRegisterState(ctx context.Context, oas *data.OAuthState) (*empty.Empty, error) {
 	if err := ds.H.Model.OAuthRegisterState(oas.State, oas.Scopes); err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -24,7 +25,7 @@ func (ds *DataServer) OAuthRegisterState(ctx context.Context, oas *data.OAuthSta
 func (ds *DataServer) OAuthValidateState(ctx context.Context, oas *data.OAuthState) (*data.OAuthState, error) {
 	o, err := ds.H.Model.OAuthValidateState(oas.State)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return o.ToProto(), nil

--- a/api/datasvc/processors/ref.go
+++ b/api/datasvc/processors/ref.go
@@ -8,13 +8,14 @@ import (
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc/codes"
 )
 
 // GetRefByNameAndSHA retrieves the ref from repository and sha data.
 func (ds *DataServer) GetRefByNameAndSHA(ctx context.Context, rp *data.RefPair) (*types.Ref, error) {
 	ref, err := ds.H.Model.GetRefByNameAndSHA(rp.RepoName, rp.Sha)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 	return ref.ToProto(), nil
 }
@@ -23,11 +24,11 @@ func (ds *DataServer) GetRefByNameAndSHA(ctx context.Context, rp *data.RefPair) 
 func (ds *DataServer) PutRef(ctx context.Context, ref *types.Ref) (*types.Ref, error) {
 	ret, err := model.NewRefFromProto(ref)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.PutRef(ret); err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return ret.ToProto(), nil
@@ -38,7 +39,7 @@ func (ds *DataServer) PutRef(ctx context.Context, ref *types.Ref) (*types.Ref, e
 // cancel runs as new ones are being submitted.
 func (ds *DataServer) CancelRefByName(ctx context.Context, rr *data.RepoRef) (*empty.Empty, error) {
 	if err := ds.H.Model.CancelRefByName(rr.Repository, rr.RefName, ds.H.URL, config.DefaultGithubClient); err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil

--- a/api/datasvc/processors/run.go
+++ b/api/datasvc/processors/run.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
 	"github.com/tinyci/ci-agents/utils"
+	"google.golang.org/grpc/codes"
 )
 
 // RunCount is the count of items in the queue
@@ -19,25 +20,25 @@ func (ds *DataServer) RunCount(ctx context.Context, rp *data.RefPair) (*data.Cou
 	if rp.RepoName != "" {
 		repo, err := ds.H.Model.GetRepositoryByName(rp.RepoName)
 		if err != nil {
-			return nil, err
+			return nil, err.ToGRPC(codes.FailedPrecondition)
 		}
 
 		if rp.Sha != "" {
 			res, err = ds.H.Model.RunTotalCountForRepositoryAndSHA(repo, rp.Sha)
 			if err != nil {
-				return nil, err
+				return nil, err.ToGRPC(codes.FailedPrecondition)
 			}
 		} else {
 			res, err = ds.H.Model.RunTotalCountForRepository(repo)
 			if err != nil {
-				return nil, err
+				return nil, err.ToGRPC(codes.FailedPrecondition)
 			}
 		}
 	} else {
 		var err *errors.Error
 		res, err = ds.H.Model.RunTotalCount()
 		if err != nil {
-			return nil, err
+			return nil, err.ToGRPC(codes.FailedPrecondition)
 		}
 	}
 
@@ -48,12 +49,12 @@ func (ds *DataServer) RunCount(ctx context.Context, rp *data.RefPair) (*data.Cou
 func (ds *DataServer) RunList(ctx context.Context, rq *data.RunListRequest) (*types.RunList, error) {
 	page, perPage, err := utils.ScopePaginationInt(rq.Page, rq.PerPage)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	list, err := ds.H.Model.RunList(page, perPage, rq.Repository, rq.Sha)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	ret := &types.RunList{}
@@ -70,7 +71,7 @@ func (ds *DataServer) GetRun(ctx context.Context, id *types.IntID) (*types.Run, 
 	run := &model.Run{}
 
 	if err := ds.H.Model.Preload("Task.Parent").Where("id = ?", id.ID).First(run).Error; err != nil {
-		return nil, errors.New(err)
+		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return run.ToProto(), nil
@@ -81,7 +82,7 @@ func (ds *DataServer) GetRunUI(ctx context.Context, id *types.IntID) (*types.Run
 	run := &model.Run{}
 
 	if err := ds.H.Model.Where("id = ?", id.ID).First(run).Error; err != nil {
-		return nil, errors.New(err)
+		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return run.ToProto(), nil

--- a/api/datasvc/processors/sessions.go
+++ b/api/datasvc/processors/sessions.go
@@ -4,15 +4,15 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc/codes"
 )
 
 // PutSession saves a session created for a user.
 func (ds *DataServer) PutSession(ctx context.Context, s *types.Session) (*empty.Empty, error) {
 	if err := ds.H.Model.SaveSession(model.NewSessionFromProto(s)); err != nil {
-		return nil, errors.New(err)
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -22,7 +22,7 @@ func (ds *DataServer) PutSession(ctx context.Context, s *types.Session) (*empty.
 func (ds *DataServer) LoadSession(ctx context.Context, id *types.StringID) (*types.Session, error) {
 	s, err := ds.H.Model.LoadSession(id.ID)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return s.ToProto(), nil

--- a/api/datasvc/processors/subscriptions.go
+++ b/api/datasvc/processors/subscriptions.go
@@ -7,22 +7,23 @@ import (
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc/codes"
 )
 
 // RemoveSubscription removes a subscription from the user's subscriptions.
 func (ds *DataServer) RemoveSubscription(ctx context.Context, rus *data.RepoUserSelection) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByName(rus.Username)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	r, err := ds.H.Model.GetRepositoryByNameForUser(rus.RepoName, u)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.RemoveSubscriptionForUser(u, r); err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -32,16 +33,16 @@ func (ds *DataServer) RemoveSubscription(ctx context.Context, rus *data.RepoUser
 func (ds *DataServer) AddSubscription(ctx context.Context, rus *data.RepoUserSelection) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByName(rus.Username)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	r, err := ds.H.Model.GetRepositoryByNameForUser(rus.RepoName, u)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.AddSubscriptionsForUser(u, []*model.Repository{r}); err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -51,7 +52,7 @@ func (ds *DataServer) AddSubscription(ctx context.Context, rus *data.RepoUserSel
 func (ds *DataServer) ListSubscriptions(ctx context.Context, nameSearch *data.NameSearch) (*types.RepositoryList, error) {
 	u, err := ds.H.Model.FindUserByNameWithSubscriptions(nameSearch.Name, nameSearch.Search)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return model.RepositoryList(u.Subscribed).ToProto(), nil

--- a/api/datasvc/processors/token.go
+++ b/api/datasvc/processors/token.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/grpc/types"
+	"google.golang.org/grpc/codes"
 )
 
 // GetToken retrieves a token, creating it if necessary, for the user supplied.
@@ -17,7 +18,7 @@ import (
 func (ds *DataServer) GetToken(ctx context.Context, name *data.Name) (*types.StringID, error) {
 	token, err := ds.H.Model.GetToken(name.Name)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &types.StringID{ID: token}, nil
@@ -27,7 +28,7 @@ func (ds *DataServer) GetToken(ctx context.Context, name *data.Name) (*types.Str
 func (ds *DataServer) DeleteToken(ctx context.Context, name *data.Name) (*empty.Empty, error) {
 	err := ds.H.Model.DeleteToken(name.Name)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -37,7 +38,7 @@ func (ds *DataServer) DeleteToken(ctx context.Context, name *data.Name) (*empty.
 func (ds *DataServer) ValidateToken(ctx context.Context, id *types.StringID) (*types.User, error) {
 	u, err := ds.H.Model.ValidateToken(id.ID)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return u.ToProto(), nil

--- a/api/datasvc/processors/user.go
+++ b/api/datasvc/processors/user.go
@@ -10,13 +10,14 @@ import (
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
 	topTypes "github.com/tinyci/ci-agents/types"
+	"google.golang.org/grpc/codes"
 )
 
 // UserByName retrieves the user by name and returns it.
 func (ds *DataServer) UserByName(ctx context.Context, name *data.Name) (*types.User, error) {
 	user, err := ds.H.Model.FindUserByName(name.Name)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return user.ToProto(), nil
@@ -27,18 +28,18 @@ func (ds *DataServer) UserByName(ctx context.Context, name *data.Name) (*types.U
 func (ds *DataServer) PatchUser(ctx context.Context, u *types.User) (*empty.Empty, error) {
 	origUser, err := ds.H.Model.FindUserByName(u.Username)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	newUser, err := model.NewUserFromProto(u)
 	if err != nil {
-		return nil, err
+		return nil, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	// for now this is the only edit possible. :)
 	origUser.Token = newUser.Token
 	if err := ds.H.Model.Save(origUser).Error; err != nil {
-		return nil, errors.New(err)
+		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -48,13 +49,13 @@ func (ds *DataServer) PatchUser(ctx context.Context, u *types.User) (*empty.Empt
 func (ds *DataServer) PutUser(ctx context.Context, u *types.User) (*types.User, error) {
 	ot := &topTypes.OAuthToken{}
 	if err := json.Unmarshal(u.TokenJSON, ot); err != nil {
-		return nil, err
+		return &types.User{}, errors.New(err).ToGRPC(codes.FailedPrecondition)
 	}
 
 	um, err := ds.H.Model.CreateUser(u.Username, ot)
 	if err != nil {
 		ds.H.Clients.Log.Errorf("Could not create user %q: %v", u.Username, err)
-		return nil, err
+		return &types.User{}, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	ds.H.Clients.Log.Infof("Created user %q", u.Username)
@@ -67,7 +68,7 @@ func (ds *DataServer) ListUsers(ctx context.Context, e *empty.Empty) (*types.Use
 	list := []*model.User{}
 
 	if err := ds.H.Model.Find(&list).Error; err != nil {
-		return nil, errors.New(err)
+		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
 	}
 
 	tu := &types.UserList{}
@@ -83,12 +84,12 @@ func (ds *DataServer) ListUsers(ctx context.Context, e *empty.Empty) (*types.Use
 func (ds *DataServer) HasCapability(ctx context.Context, cr *data.CapabilityRequest) (*types.Bool, error) {
 	u, err := ds.H.Model.FindUserByID(cr.Id)
 	if err != nil {
-		return &types.Bool{Result: false}, err
+		return &types.Bool{Result: false}, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	res, err := ds.H.Model.HasCapability(u, model.Capability(cr.Capability), ds.H.Auth.FixedCapabilities)
 	if err != nil {
-		return &types.Bool{Result: false}, err
+		return &types.Bool{Result: false}, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &types.Bool{Result: res}, nil
@@ -98,11 +99,11 @@ func (ds *DataServer) HasCapability(ctx context.Context, cr *data.CapabilityRequ
 func (ds *DataServer) AddCapability(ctx context.Context, cr *data.CapabilityRequest) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByID(cr.Id)
 	if err != nil {
-		return &empty.Empty{}, err
+		return &empty.Empty{}, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.AddCapabilityToUser(u, model.Capability(cr.Capability)); err != nil {
-		return &empty.Empty{}, err
+		return &empty.Empty{}, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -112,11 +113,11 @@ func (ds *DataServer) AddCapability(ctx context.Context, cr *data.CapabilityRequ
 func (ds *DataServer) RemoveCapability(ctx context.Context, cr *data.CapabilityRequest) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByID(cr.Id)
 	if err != nil {
-		return &empty.Empty{}, err
+		return &empty.Empty{}, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.RemoveCapabilityFromUser(u, model.Capability(cr.Capability)); err != nil {
-		return &empty.Empty{}, err
+		return &empty.Empty{}, err.ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil

--- a/api/datasvc/test/setup_test.go
+++ b/api/datasvc/test/setup_test.go
@@ -13,10 +13,12 @@ import (
 )
 
 type datasvcSuite struct {
-	model      *model.Model
-	doneChan   chan struct{}
-	dataServer *handler.H
-	client     *testclients.DataClient
+	model        *model.Model
+	dataDoneChan chan struct{}
+	dataServer   *handler.H
+	logDoneChan  chan struct{}
+	logServer    *handler.H
+	client       *testclients.DataClient
 }
 
 var _ = check.Suite(&datasvcSuite{})
@@ -32,7 +34,10 @@ func (ds *datasvcSuite) SetUpTest(c *check.C) {
 	ds.model, err = model.New(testutil.TestDBConfig)
 	c.Assert(err, check.IsNil)
 
-	ds.dataServer, ds.doneChan, err = testservers.MakeDataServer()
+	ds.dataServer, ds.dataDoneChan, err = testservers.MakeDataServer()
+	c.Assert(err, check.IsNil)
+
+	ds.logServer, ds.logDoneChan, _, err = testservers.MakeLogServer()
 	c.Assert(err, check.IsNil)
 
 	ds.client, err = testclients.NewDataClient()
@@ -40,6 +45,7 @@ func (ds *datasvcSuite) SetUpTest(c *check.C) {
 }
 
 func (ds *datasvcSuite) TearDownTest(c *check.C) {
-	close(ds.doneChan)
+	close(ds.logDoneChan)
+	close(ds.dataDoneChan)
 	time.Sleep(100 * time.Millisecond)
 }

--- a/api/logsvc/processors/submit.go
+++ b/api/logsvc/processors/submit.go
@@ -8,13 +8,14 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/services/log"
+	"google.golang.org/grpc/codes"
 )
 
 // Put submits a log message to the service, which in our current case, echoes it to stdout by way of sirupsen/logrus.
 func (ls *LogServer) Put(ctx context.Context, lm *log.LogMessage) (*empty.Empty, error) {
 	dispatcher, ok := ls.DispatchTable[lm.GetLevel()]
 	if !ok {
-		return &empty.Empty{}, errors.Errorf("Invalid log level %q", lm.GetLevel())
+		return &empty.Empty{}, errors.Errorf("Invalid log level %q", lm.GetLevel()).ToGRPC(codes.FailedPrecondition)
 	}
 
 	fields := map[string]interface{}{}
@@ -24,7 +25,7 @@ func (ls *LogServer) Put(ctx context.Context, lm *log.LogMessage) (*empty.Empty,
 		case *_struct.Value_StringValue:
 			fields[key] = kind.StringValue
 		default:
-			return &empty.Empty{}, errors.Errorf("%q must be a string value", key)
+			return &empty.Empty{}, errors.Errorf("%q must be a string value", key).ToGRPC(codes.FailedPrecondition)
 		}
 	}
 

--- a/api/queuesvc/test/setup_test.go
+++ b/api/queuesvc/test/setup_test.go
@@ -19,8 +19,10 @@ type queuesvcSuite struct {
 	queuesvcClient *testclients.QueueClient
 	queueDoneChan  chan struct{}
 	dataDoneChan   chan struct{}
+	logDoneChan    chan struct{}
 	model          *model.Model
 	dataHandler    *handler.H
+	logHandler     *handler.H
 	queueHandler   *handler.H
 }
 
@@ -40,6 +42,9 @@ func (qs *queuesvcSuite) SetUpTest(c *check.C) {
 	qs.dataHandler, qs.dataDoneChan, err = testservers.MakeDataServer()
 	c.Assert(err, check.IsNil)
 
+	qs.logHandler, qs.logDoneChan, _, err = testservers.MakeLogServer()
+	c.Assert(err, check.IsNil)
+
 	qs.queueHandler, qs.queueDoneChan, err = testservers.MakeQueueServer()
 	c.Assert(err, check.IsNil)
 
@@ -51,6 +56,7 @@ func (qs *queuesvcSuite) SetUpTest(c *check.C) {
 }
 
 func (qs *queuesvcSuite) TearDownTest(c *check.C) {
+	close(qs.logDoneChan)
 	close(qs.dataDoneChan)
 	close(qs.queueDoneChan)
 	time.Sleep(100 * time.Millisecond)

--- a/clients/asset/asset.go
+++ b/clients/asset/asset.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/services/asset"
 	"github.com/tinyci/ci-agents/grpc/types"
+	"google.golang.org/grpc"
 )
 
 // Client is a handle into the asset client.
@@ -26,7 +27,7 @@ func NewClient(cert *transport.Cert, addr string) (*Client, *errors.Error) {
 
 // Write writes a log at id with the supplied reader providing the content.
 func (c *Client) Write(id int64, f io.Reader) *errors.Error {
-	s, err := c.ac.PutLog(context.Background())
+	s, err := c.ac.PutLog(context.Background(), grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -64,7 +65,7 @@ func (c *Client) Write(id int64, f io.Reader) *errors.Error {
 }
 
 func (c *Client) Read(id int64, w io.Writer) *errors.Error {
-	as, err := c.ac.GetLog(context.Background(), &types.IntID{ID: id})
+	as, err := c.ac.GetLog(context.Background(), &types.IntID{ID: id}, grpc.WaitForReady(false))
 	if err != nil {
 		return errors.New(err)
 	}

--- a/clients/asset/task.yml
+++ b/clients/asset/task.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - api/assetsvc

--- a/clients/data/errors.go
+++ b/clients/data/errors.go
@@ -7,11 +7,12 @@ import (
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 // GetErrors retrieves all the errors for the user.
 func (c *Client) GetErrors(name string) ([]*model.UserError, *errors.Error) {
-	errs, err := c.client.GetErrors(context.Background(), &data.Name{Name: name})
+	errs, err := c.client.GetErrors(context.Background(), &data.Name{Name: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -27,12 +28,12 @@ func (c *Client) GetErrors(name string) ([]*model.UserError, *errors.Error) {
 
 // AddError adds an error.
 func (c *Client) AddError(msg, username string) *errors.Error {
-	u, err := c.client.UserByName(context.Background(), &data.Name{Name: username})
+	u, err := c.client.UserByName(context.Background(), &data.Name{Name: username}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
 
-	_, err = c.client.AddError(context.Background(), &types.UserError{Error: msg, UserID: u.Id})
+	_, err = c.client.AddError(context.Background(), &types.UserError{Error: msg, UserID: u.Id}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -42,6 +43,6 @@ func (c *Client) AddError(msg, username string) *errors.Error {
 
 // DeleteError removes an error.
 func (c *Client) DeleteError(id, userID int64) *errors.Error {
-	_, err := c.client.DeleteError(context.Background(), &types.UserError{Id: id, UserID: userID})
+	_, err := c.client.DeleteError(context.Background(), &types.UserError{Id: id, UserID: userID}, grpc.WaitForReady(true))
 	return errors.New(err)
 }

--- a/clients/data/oauth.go
+++ b/clients/data/oauth.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/services/data"
+	"google.golang.org/grpc"
 )
 
 // OAuthValidateState validates the state in the database.
 func (c *Client) OAuthValidateState(state string) ([]string, *errors.Error) {
-	oas, err := c.client.OAuthValidateState(context.Background(), &data.OAuthState{State: state})
+	oas, err := c.client.OAuthValidateState(context.Background(), &data.OAuthState{State: state}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -19,6 +20,6 @@ func (c *Client) OAuthValidateState(state string) ([]string, *errors.Error) {
 
 // OAuthRegisterState registers the oauth state in the database.
 func (c *Client) OAuthRegisterState(state string, scopes []string) *errors.Error {
-	_, err := c.client.OAuthRegisterState(context.Background(), &data.OAuthState{State: state, Scopes: scopes})
+	_, err := c.client.OAuthRegisterState(context.Background(), &data.OAuthState{State: state, Scopes: scopes}, grpc.WaitForReady(true))
 	return errors.New(err)
 }

--- a/clients/data/ref.go
+++ b/clients/data/ref.go
@@ -6,11 +6,12 @@ import (
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 // PutRef adds a ref to the database.
 func (c *Client) PutRef(ref *model.Ref) (int64, *errors.Error) {
-	id, err := c.client.PutRef(context.Background(), ref.ToProto())
+	id, err := c.client.PutRef(context.Background(), ref.ToProto(), grpc.WaitForReady(true))
 	if err != nil {
 		return 0, errors.New(err)
 	}
@@ -20,13 +21,13 @@ func (c *Client) PutRef(ref *model.Ref) (int64, *errors.Error) {
 
 // CancelRefByName cancels all jobs for a ref by name
 func (c *Client) CancelRefByName(repoID int64, ref string) *errors.Error {
-	_, err := c.client.CancelRefByName(context.Background(), &data.RepoRef{Repository: repoID, RefName: ref})
+	_, err := c.client.CancelRefByName(context.Background(), &data.RepoRef{Repository: repoID, RefName: ref}, grpc.WaitForReady(true))
 	return errors.New(err)
 }
 
 // GetRefByNameAndSHA retrieves a ref by it's repo name and SHA
 func (c *Client) GetRefByNameAndSHA(repoName, sha string) (*model.Ref, *errors.Error) {
-	ref, err := c.client.GetRefByNameAndSHA(context.Background(), &data.RefPair{RepoName: repoName, Sha: sha})
+	ref, err := c.client.GetRefByNameAndSHA(context.Background(), &data.RefPair{RepoName: repoName, Sha: sha}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}

--- a/clients/data/repository.go
+++ b/clients/data/repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 func makeRepoList(list *types.RepositoryList) (model.RepositoryList, *errors.Error) {
@@ -28,7 +29,7 @@ func makeRepoList(list *types.RepositoryList) (model.RepositoryList, *errors.Err
 
 // GetRepository retrieves a repository by name.
 func (c *Client) GetRepository(name string) (*model.Repository, *errors.Error) {
-	repo, err := c.client.GetRepository(context.Background(), &data.Name{Name: name})
+	repo, err := c.client.GetRepository(context.Background(), &data.Name{Name: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -43,7 +44,7 @@ func (c *Client) PutRepositories(name string, github []*github.Repository, autoC
 		return errors.New(err)
 	}
 
-	_, err = c.client.SaveRepositories(context.Background(), &data.GithubJSON{JSON: content, Username: name, AutoCreated: autoCreated})
+	_, err = c.client.SaveRepositories(context.Background(), &data.GithubJSON{JSON: content, Username: name, AutoCreated: autoCreated}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -53,7 +54,7 @@ func (c *Client) PutRepositories(name string, github []*github.Repository, autoC
 
 // EnableRepository enables a repository in CI for a user as owner.
 func (c *Client) EnableRepository(user, name string) *errors.Error {
-	_, err := c.client.EnableRepository(context.Background(), &data.RepoUserSelection{Username: user, RepoName: name})
+	_, err := c.client.EnableRepository(context.Background(), &data.RepoUserSelection{Username: user, RepoName: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -63,7 +64,7 @@ func (c *Client) EnableRepository(user, name string) *errors.Error {
 
 // DisableRepository disabls a repository in CI for a user as owner.
 func (c *Client) DisableRepository(user, name string) *errors.Error {
-	_, err := c.client.DisableRepository(context.Background(), &data.RepoUserSelection{Username: user, RepoName: name})
+	_, err := c.client.DisableRepository(context.Background(), &data.RepoUserSelection{Username: user, RepoName: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -73,7 +74,7 @@ func (c *Client) DisableRepository(user, name string) *errors.Error {
 
 // OwnedRepositories lists the owned repositories by the user.
 func (c *Client) OwnedRepositories(name, search string) (model.RepositoryList, *errors.Error) {
-	list, err := c.client.OwnedRepositories(context.Background(), &data.NameSearch{Name: name, Search: search})
+	list, err := c.client.OwnedRepositories(context.Background(), &data.NameSearch{Name: name, Search: search}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -83,7 +84,7 @@ func (c *Client) OwnedRepositories(name, search string) (model.RepositoryList, *
 
 // AllRepositories lists all visible repositories by the user.
 func (c *Client) AllRepositories(name, search string) (model.RepositoryList, *errors.Error) {
-	list, err := c.client.AllRepositories(context.Background(), &data.NameSearch{Name: name, Search: search})
+	list, err := c.client.AllRepositories(context.Background(), &data.NameSearch{Name: name, Search: search}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -93,7 +94,7 @@ func (c *Client) AllRepositories(name, search string) (model.RepositoryList, *er
 
 // PrivateRepositories lists all visible private repositories by the user.
 func (c *Client) PrivateRepositories(name, search string) (model.RepositoryList, *errors.Error) {
-	list, err := c.client.PrivateRepositories(context.Background(), &data.NameSearch{Name: name, Search: search})
+	list, err := c.client.PrivateRepositories(context.Background(), &data.NameSearch{Name: name, Search: search}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -103,7 +104,7 @@ func (c *Client) PrivateRepositories(name, search string) (model.RepositoryList,
 
 // PublicRepositories lists all owned public repositories by the user.
 func (c *Client) PublicRepositories(search string) (model.RepositoryList, *errors.Error) {
-	list, err := c.client.PublicRepositories(context.Background(), &data.Search{Search: search})
+	list, err := c.client.PublicRepositories(context.Background(), &data.Search{Search: search}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}

--- a/clients/data/run.go
+++ b/clients/data/run.go
@@ -7,11 +7,12 @@ import (
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 // RunCount returns the count of all items that match the repoName and sha.
 func (c *Client) RunCount(repoName, sha string) (int64, *errors.Error) {
-	count, err := c.client.RunCount(context.Background(), &data.RefPair{RepoName: repoName, Sha: sha})
+	count, err := c.client.RunCount(context.Background(), &data.RefPair{RepoName: repoName, Sha: sha}, grpc.WaitForReady(true))
 	if err != nil {
 		return 0, errors.New(err)
 	}
@@ -21,7 +22,7 @@ func (c *Client) RunCount(repoName, sha string) (int64, *errors.Error) {
 
 // ListRuns lists runs by repository name and sha
 func (c *Client) ListRuns(repoName, sha string, page, perPage int64) ([]*model.Run, *errors.Error) {
-	list, err := c.client.RunList(context.Background(), &data.RunListRequest{Repository: repoName, Sha: sha, Page: page, PerPage: perPage})
+	list, err := c.client.RunList(context.Background(), &data.RunListRequest{Repository: repoName, Sha: sha, Page: page, PerPage: perPage}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -42,7 +43,7 @@ func (c *Client) ListRuns(repoName, sha string, page, perPage int64) ([]*model.R
 
 // GetRun retrieves a run by id.
 func (c *Client) GetRun(id int64) (*model.Run, *errors.Error) {
-	run, err := c.client.GetRun(context.Background(), &types.IntID{ID: id})
+	run, err := c.client.GetRun(context.Background(), &types.IntID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -52,7 +53,7 @@ func (c *Client) GetRun(id int64) (*model.Run, *errors.Error) {
 
 // GetRunUI retrieves a run by id.
 func (c *Client) GetRunUI(id int64) (*model.Run, *errors.Error) {
-	run, err := c.client.GetRunUI(context.Background(), &types.IntID{ID: id})
+	run, err := c.client.GetRunUI(context.Background(), &types.IntID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}

--- a/clients/data/session.go
+++ b/clients/data/session.go
@@ -6,11 +6,12 @@ import (
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 // GetSession retrieves a session from the database by id.
 func (c *Client) GetSession(id string) (*model.Session, *errors.Error) {
-	s, err := c.client.LoadSession(context.Background(), &types.StringID{ID: id})
+	s, err := c.client.LoadSession(context.Background(), &types.StringID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -20,6 +21,6 @@ func (c *Client) GetSession(id string) (*model.Session, *errors.Error) {
 
 // PutSession adds a session to the database.
 func (c *Client) PutSession(s *model.Session) *errors.Error {
-	_, err := c.client.PutSession(context.Background(), s.ToProto())
+	_, err := c.client.PutSession(context.Background(), s.ToProto(), grpc.WaitForReady(true))
 	return errors.New(err)
 }

--- a/clients/data/subscriptions.go
+++ b/clients/data/subscriptions.go
@@ -6,11 +6,12 @@ import (
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 // ListSubscriptions lists the subscriptions that the user has selected.
 func (c *Client) ListSubscriptions(name, search string) (model.RepositoryList, *errors.Error) {
-	rl, err := c.client.ListSubscriptions(context.Background(), &data.NameSearch{Name: name, Search: search})
+	rl, err := c.client.ListSubscriptions(context.Background(), &data.NameSearch{Name: name, Search: search}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -20,7 +21,7 @@ func (c *Client) ListSubscriptions(name, search string) (model.RepositoryList, *
 
 // AddSubscription adds a subscription for the user.
 func (c *Client) AddSubscription(name, repo string) *errors.Error {
-	_, err := c.client.AddSubscription(context.Background(), &data.RepoUserSelection{RepoName: repo, Username: name})
+	_, err := c.client.AddSubscription(context.Background(), &data.RepoUserSelection{RepoName: repo, Username: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -31,7 +32,7 @@ func (c *Client) AddSubscription(name, repo string) *errors.Error {
 // DeleteSubscription removes a subscription for the user.
 func (c *Client) DeleteSubscription(name, repo string) *errors.Error {
 	// sigh.. these names.
-	_, err := c.client.RemoveSubscription(context.Background(), &data.RepoUserSelection{RepoName: repo, Username: name})
+	_, err := c.client.RemoveSubscription(context.Background(), &data.RepoUserSelection{RepoName: repo, Username: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}

--- a/clients/data/task.go
+++ b/clients/data/task.go
@@ -7,11 +7,12 @@ import (
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 // CancelTasksByPR cancels tasks by PR ID.
 func (c *Client) CancelTasksByPR(repository string, prID int64) *errors.Error {
-	if _, err := c.client.CancelTasksByPR(context.Background(), &types.CancelPRRequest{Repository: repository, Id: prID}); err != nil {
+	if _, err := c.client.CancelTasksByPR(context.Background(), &types.CancelPRRequest{Repository: repository, Id: prID}, grpc.WaitForReady(true)); err != nil {
 		return errors.New(err)
 	}
 
@@ -20,7 +21,7 @@ func (c *Client) CancelTasksByPR(repository string, prID int64) *errors.Error {
 
 // PutTask adds a task to the database.
 func (c *Client) PutTask(task *model.Task) (*model.Task, *errors.Error) {
-	t, err := c.client.PutTask(context.Background(), task.ToProto())
+	t, err := c.client.PutTask(context.Background(), task.ToProto(), grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -37,7 +38,7 @@ func (c *Client) ListTasks(repository, sha string, page, perPage int64) ([]*mode
 		Sha:        sha,
 		Page:       page,
 		PerPage:    perPage,
-	})
+	}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -58,7 +59,7 @@ func (c *Client) ListTasks(repository, sha string, page, perPage int64) ([]*mode
 
 // CountTasks counts the tasks with the filters applied.
 func (c *Client) CountTasks(repository, sha string) (int64, *errors.Error) {
-	count, err := c.client.CountTasks(context.Background(), &data.TaskListRequest{Repository: repository, Sha: sha})
+	count, err := c.client.CountTasks(context.Background(), &data.TaskListRequest{Repository: repository, Sha: sha}, grpc.WaitForReady(true))
 	if err != nil {
 		return 0, errors.New(err)
 	}
@@ -68,7 +69,7 @@ func (c *Client) CountTasks(repository, sha string) (int64, *errors.Error) {
 
 // GetRunsForTask retrieves all the runs by task ID.
 func (c *Client) GetRunsForTask(taskID, page, perPage int64) ([]*model.Run, *errors.Error) {
-	runs, err := c.client.RunsForTask(context.Background(), &data.RunsForTaskRequest{Id: taskID, Page: page, PerPage: perPage})
+	runs, err := c.client.RunsForTask(context.Background(), &data.RunsForTaskRequest{Id: taskID, Page: page, PerPage: perPage}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -89,7 +90,7 @@ func (c *Client) GetRunsForTask(taskID, page, perPage int64) ([]*model.Run, *err
 
 // CountRunsForTask counts all the runs associated with the task.
 func (c *Client) CountRunsForTask(taskID int64) (int64, *errors.Error) {
-	count, err := c.client.CountRunsForTask(context.Background(), &types.IntID{ID: taskID})
+	count, err := c.client.CountRunsForTask(context.Background(), &types.IntID{ID: taskID}, grpc.WaitForReady(true))
 	if err != nil {
 		return 0, errors.New(err)
 	}
@@ -101,7 +102,7 @@ func (c *Client) CountRunsForTask(taskID int64) (int64, *errors.Error) {
 func (c *Client) ListSubscribedTasksForUser(userID, page, perPage int64) ([]*model.Task, *errors.Error) {
 	modelTasks := []*model.Task{}
 
-	tasks, err := c.client.ListSubscribedTasksForUser(context.Background(), &data.ListSubscribedTasksRequest{Id: userID, Page: page, PerPage: perPage})
+	tasks, err := c.client.ListSubscribedTasksForUser(context.Background(), &data.ListSubscribedTasksRequest{Id: userID, Page: page, PerPage: perPage}, grpc.WaitForReady(true))
 	if err != nil {
 		return modelTasks, errors.New(err)
 	}

--- a/clients/data/task.yml
+++ b/clients/data/task.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - api/datasvc

--- a/clients/data/token.go
+++ b/clients/data/token.go
@@ -7,13 +7,14 @@ import (
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 // GetToken returns a newly minted access token to tinyCI or error otherwise.
 // To get a new token with this method, call the DeleteToken method first if
 // one exists already.
 func (c *Client) GetToken(username string) (string, *errors.Error) {
-	token, err := c.client.GetToken(context.Background(), &data.Name{Name: username})
+	token, err := c.client.GetToken(context.Background(), &data.Name{Name: username}, grpc.WaitForReady(true))
 	if err != nil {
 		return "", errors.New(err)
 	}
@@ -24,7 +25,7 @@ func (c *Client) GetToken(username string) (string, *errors.Error) {
 // DeleteToken removes the existing access token and makes it available to be
 // regenerated.
 func (c *Client) DeleteToken(username string) *errors.Error {
-	_, err := c.client.DeleteToken(context.Background(), &data.Name{Name: username})
+	_, err := c.client.DeleteToken(context.Background(), &data.Name{Name: username}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -33,7 +34,7 @@ func (c *Client) DeleteToken(username string) *errors.Error {
 
 // ValidateToken validates the token and returns error if it is not valid somehow.
 func (c *Client) ValidateToken(token string) (*model.User, *errors.Error) {
-	user, err := c.client.ValidateToken(context.Background(), &types.StringID{ID: token})
+	user, err := c.client.ValidateToken(context.Background(), &types.StringID{ID: token}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}

--- a/clients/data/user.go
+++ b/clients/data/user.go
@@ -7,11 +7,12 @@ import (
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/services/data"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 // PatchUser adjusts the token for the user.
 func (c *Client) PatchUser(u *model.User) *errors.Error {
-	_, err := c.client.PatchUser(context.Background(), u.ToProto())
+	_, err := c.client.PatchUser(context.Background(), u.ToProto(), grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -21,7 +22,7 @@ func (c *Client) PatchUser(u *model.User) *errors.Error {
 
 // PutUser inserts the user provided.
 func (c *Client) PutUser(u *model.User) (*model.User, *errors.Error) {
-	u2, err := c.client.PutUser(context.Background(), u.ToProto())
+	u2, err := c.client.PutUser(context.Background(), u.ToProto(), grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -31,7 +32,7 @@ func (c *Client) PutUser(u *model.User) (*model.User, *errors.Error) {
 
 // GetUser obtains a user record by name
 func (c *Client) GetUser(name string) (*model.User, *errors.Error) {
-	u, err := c.client.UserByName(context.Background(), &data.Name{Name: name})
+	u, err := c.client.UserByName(context.Background(), &data.Name{Name: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -41,7 +42,7 @@ func (c *Client) GetUser(name string) (*model.User, *errors.Error) {
 
 // ListUsers lists the users in the system.
 func (c *Client) ListUsers() ([]*model.User, *errors.Error) {
-	users, err := c.client.ListUsers(context.Background(), &empty.Empty{})
+	users, err := c.client.ListUsers(context.Background(), &empty.Empty{}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -62,7 +63,7 @@ func (c *Client) ListUsers() ([]*model.User, *errors.Error) {
 
 // HasCapability returns true if the user has the specified capability.
 func (c *Client) HasCapability(u *model.User, cap model.Capability) (bool, *errors.Error) {
-	res, err := c.client.HasCapability(context.Background(), &data.CapabilityRequest{Id: u.ID, Capability: string(cap)})
+	res, err := c.client.HasCapability(context.Background(), &data.CapabilityRequest{Id: u.ID, Capability: string(cap)}, grpc.WaitForReady(true))
 	if err != nil {
 		return false, errors.New(err)
 	}
@@ -72,7 +73,7 @@ func (c *Client) HasCapability(u *model.User, cap model.Capability) (bool, *erro
 
 // AddCapability adds a capability for a user.
 func (c *Client) AddCapability(u *model.User, cap model.Capability) *errors.Error {
-	_, err := c.client.AddCapability(context.Background(), &data.CapabilityRequest{Id: u.ID, Capability: string(cap)})
+	_, err := c.client.AddCapability(context.Background(), &data.CapabilityRequest{Id: u.ID, Capability: string(cap)}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -82,7 +83,7 @@ func (c *Client) AddCapability(u *model.User, cap model.Capability) *errors.Erro
 
 // RemoveCapability removes a capability from a user.
 func (c *Client) RemoveCapability(u *model.User, cap model.Capability) *errors.Error {
-	_, err := c.client.RemoveCapability(context.Background(), &data.CapabilityRequest{Id: u.ID, Capability: string(cap)})
+	_, err := c.client.RemoveCapability(context.Background(), &data.CapabilityRequest{Id: u.ID, Capability: string(cap)}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}

--- a/clients/log/log.go
+++ b/clients/log/log.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/services/log"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 // RemoteClient is the swagger-based syslogsvc client.
@@ -189,7 +190,7 @@ func (sub *SubLogger) makeMsg(level, msg string, values []interface{}) *log.LogM
 // Logf logs a thing with formats!
 func (sub *SubLogger) Logf(level string, msg string, values []interface{}, localLog func(string, ...interface{})) *errors.Error {
 	if RemoteClient != nil {
-		_, err := RemoteClient.Put(context.Background(), sub.makeMsg(level, msg, values))
+		_, err := RemoteClient.Put(context.Background(), sub.makeMsg(level, msg, values), grpc.WaitForReady(true))
 		return errors.New(err)
 	}
 
@@ -200,7 +201,7 @@ func (sub *SubLogger) Logf(level string, msg string, values []interface{}, local
 // Log logs a thing
 func (sub *SubLogger) Log(level string, msg interface{}, localLog func(...interface{})) *errors.Error {
 	if RemoteClient != nil {
-		_, err := RemoteClient.Put(context.Background(), sub.makeMsg(level, fmt.Sprintf("%v", msg), nil))
+		_, err := RemoteClient.Put(context.Background(), sub.makeMsg(level, fmt.Sprintf("%v", msg), nil), grpc.WaitForReady(true))
 		return errors.New(err)
 	}
 

--- a/clients/log/task.yml
+++ b/clients/log/task.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - api/logsvc

--- a/clients/queue/client.go
+++ b/clients/queue/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tinyci/ci-agents/grpc/services/queue"
 	"github.com/tinyci/ci-agents/grpc/types"
 	"github.com/tinyci/ci-agents/model"
+	"google.golang.org/grpc"
 )
 
 // Client is the queue client.
@@ -27,7 +28,7 @@ func New(addr string, cert *transport.Cert) (*Client, *errors.Error) {
 
 // GetCancel retrieves the cancel state of the run.
 func (c *Client) GetCancel(id int64) (bool, *errors.Error) {
-	status, err := c.client.GetCancel(context.Background(), &types.IntID{ID: id})
+	status, err := c.client.GetCancel(context.Background(), &types.IntID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return false, errors.New(err)
 	}
@@ -37,7 +38,7 @@ func (c *Client) GetCancel(id int64) (bool, *errors.Error) {
 
 // SetCancel sets the cancel state for a given run id.
 func (c *Client) SetCancel(id int64) *errors.Error {
-	_, err := c.client.SetCancel(context.Background(), &types.IntID{ID: id})
+	_, err := c.client.SetCancel(context.Background(), &types.IntID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}
@@ -47,7 +48,7 @@ func (c *Client) SetCancel(id int64) *errors.Error {
 
 // NextQueueItem returns the next item in the queue.
 func (c *Client) NextQueueItem(queueName, hostname string) (*model.QueueItem, *errors.Error) {
-	qi, err := c.client.NextQueueItem(context.Background(), &types.QueueRequest{QueueName: queueName, RunningOn: hostname})
+	qi, err := c.client.NextQueueItem(context.Background(), &types.QueueRequest{QueueName: queueName, RunningOn: hostname}, grpc.WaitForReady(false))
 	if err != nil {
 		return nil, errors.New(err)
 	}
@@ -57,7 +58,7 @@ func (c *Client) NextQueueItem(queueName, hostname string) (*model.QueueItem, *e
 
 // SetStatus completes the run by returning its status back to the system.
 func (c *Client) SetStatus(id int64, status bool) *errors.Error {
-	_, err := c.client.PutStatus(context.Background(), &types.Status{Id: id, Status: status})
+	_, err := c.client.PutStatus(context.Background(), &types.Status{Id: id, Status: status}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
 	}

--- a/clients/queue/submit.go
+++ b/clients/queue/submit.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/grpc/services/queue"
 	"github.com/tinyci/ci-agents/types"
+	"google.golang.org/grpc"
 )
 
 // Submit submits a push or pull request to the queue.
@@ -19,6 +20,6 @@ func (c *Client) Submit(sub *types.Submission) *errors.Error {
 		SubmittedBy: sub.SubmittedBy,
 		Manual:      sub.Manual,
 		PullRequest: sub.PullRequest,
-	})
+	}, grpc.WaitForReady(true))
 	return errors.New(err)
 }

--- a/clients/queue/task.yml
+++ b/clients/queue/task.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - api/queuesvc

--- a/clients/tinyci/task.yml
+++ b/clients/tinyci/task.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - api/uisvc

--- a/errors/error.go
+++ b/errors/error.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"golang.org/x/xerrors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Error encapsulates a series of errors.
@@ -50,6 +52,11 @@ func doinit(str string, log bool) *Error {
 // NewNoLog returns an error which will not be logged.
 func NewNoLog(str string) *Error {
 	return doinit(str, false)
+}
+
+// ToGRPC converts an error to a coded GRPC error, useful in returns from API handlers.
+func (e *Error) ToGRPC(code codes.Code) error {
+	return status.Errorf(code, "%v", e)
 }
 
 // SetLog sets the state for whether or not logging is permitted.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -120,13 +120,13 @@ golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20190328230028-74de082e2cca
 golang.org/x/net/websocket
 golang.org/x/net/trace
-golang.org/x/net/context/ctxhttp
 golang.org/x/net/internal/timeseries
 golang.org/x/net/http2
 golang.org/x/net/http2/hpack
-golang.org/x/net/context
+golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
 golang.org/x/net/idna
+golang.org/x/net/context
 # golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914
 golang.org/x/oauth2
 golang.org/x/oauth2/github
@@ -154,9 +154,9 @@ google.golang.org/appengine/internal/remote_api
 # google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.19.1
+google.golang.org/grpc/codes
 google.golang.org/grpc/metadata
 google.golang.org/grpc
-google.golang.org/grpc/codes
 google.golang.org/grpc/status
 google.golang.org/grpc/credentials
 google.golang.org/grpc/balancer


### PR DESCRIPTION
This leverages grpc.WaitForReady in all client calls except a few -- who
were given FailFast instead.

This also adds GRPC coding to all errors returned from services.

Closes #11 

Signed-off-by: Erik Hollensbe <github@hollensbe.org>