### PR TITLE
tinycli: instead of reporting ".", it now reports "*root*"

### DIFF
--- a/cmd/tinycli/main.go
+++ b/cmd/tinycli/main.go
@@ -338,7 +338,12 @@ func tasks(ctx *cli.Context) error {
 			return err
 		}
 
-		w.Write([]byte(fmt.Sprintf("%d\t%s\t%s\t%s\t%s\t%d/%d/%d\t%s\t%s\n", task.ID, task.Ref.Repository.Name, refName, sha, task.Path, runningCount, finishedCount, totalCount, statusStr, duration)))
+		path := task.Path
+		if path == "." {
+			path = "*root*"
+		}
+
+		w.Write([]byte(fmt.Sprintf("%d\t%s\t%s\t%s\t%s\t%d/%d/%d\t%s\t%s\n", task.ID, task.Ref.Repository.Name, refName, sha, path, runningCount, finishedCount, totalCount, statusStr, duration)))
 	}
 	w.Flush()
 

--- a/cmd/tinycli/main.go
+++ b/cmd/tinycli/main.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/tinyci/ci-agents/clients/tinyci"
 	"github.com/tinyci/ci-agents/errors"
@@ -327,7 +328,9 @@ func tasks(ctx *cli.Context) error {
 
 		if task.StartedAt != nil && task.FinishedAt != nil {
 			d := task.FinishedAt.Sub(*task.StartedAt)
-			duration = d.String()
+			duration = d.Round(time.Millisecond).String()
+		} else if task.StartedAt != nil {
+			duration = time.Since(*task.StartedAt).Round(time.Millisecond).String()
 		}
 
 		refName := task.Ref.RefName
@@ -380,7 +383,7 @@ func runs(ctx *cli.Context) error {
 		duration := ""
 
 		if run.StartedAt != nil && run.FinishedAt != nil {
-			d := run.FinishedAt.Sub(*run.StartedAt)
+			d := run.FinishedAt.Sub(*run.StartedAt).Round(time.Millisecond)
 			duration = d.String()
 		}
 

--- a/model/queue.go
+++ b/model/queue.go
@@ -166,7 +166,8 @@ func (m *Model) NextQueueItem(runningOn string, queueName string) (*QueueItem, *
 	qi.StartedAt = &t
 	qi.Run.StartedAt = &t
 	if qi.Run.Task.StartedAt == nil {
-		if err := m.WrapError(db.Model(qi.Run.Task).Update("started_at = ?", &t), "updating task started_at"); err != nil {
+		qi.Run.Task.StartedAt = &t
+		if err := m.WrapError(db.Save(qi.Run.Task), "updating task started_at"); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
To be consistent with other UI implementations.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>