### PR TITLE
Return an error instead of trying to redirect on oauth2 scope issues

### DIFF
--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -357,11 +357,7 @@ func (h *H) authed(gatewayFunc func(*H, *gin.Context, HandlerFunc) *errors.Error
 		}
 
 		if scope != "" && !u.Token.Can(scope) {
-			if err := h.OAuthRedirect(ctx, append([]string{scope}, u.Token.Scopes...)); err != nil {
-				return err
-			}
-
-			return ErrRedirect
+			return errors.New("cannot perform operation with current oauth scopes; must upgrade")
 		}
 
 		return gatewayFunc(h, ctx, processor)


### PR DESCRIPTION
closes tinyci/ci-ui#36

Signed-off-by: Erik Hollensbe <github@hollensbe.org>