### PR TITLE
cmd,errors: handle exit more generically and predictably

### DIFF
--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -38,11 +38,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		if e, ok := err.(*errors.Error); ok && e == nil {
-			return
-		}
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		errors.New(err).Exit()
 	}
 }
 

--- a/cmd/cancelbot/main.go
+++ b/cmd/cancelbot/main.go
@@ -62,8 +62,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		errors.New(err).Exit()
 	}
 }
 

--- a/cmd/datasvc/main.go
+++ b/cmd/datasvc/main.go
@@ -38,11 +38,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		if e, ok := err.(*errors.Error); ok && e == nil {
-			return
-		}
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		errors.New(err).Exit()
 	}
 }
 

--- a/cmd/hooksvc/main.go
+++ b/cmd/hooksvc/main.go
@@ -26,10 +26,8 @@ func main() {
 
 	app.Action = serve
 
-	err := app.Run(os.Args)
-	if e, _ := err.(*errors.Error); e != nil {
-		fmt.Fprintln(os.Stderr, e.Error())
-		os.Exit(1)
+	if err := app.Run(os.Args); err != nil {
+		errors.New(err).Exit()
 	}
 }
 

--- a/cmd/logsvc/main.go
+++ b/cmd/logsvc/main.go
@@ -38,11 +38,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		if e, ok := err.(*errors.Error); ok && e == nil {
-			return
-		}
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		errors.New(err).Exit()
 	}
 }
 

--- a/cmd/queuesvc/main.go
+++ b/cmd/queuesvc/main.go
@@ -38,11 +38,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		if e, ok := err.(*errors.Error); ok && e == nil {
-			return
-		}
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		errors.New(err).Exit()
 	}
 }
 

--- a/cmd/tinycli/main.go
+++ b/cmd/tinycli/main.go
@@ -217,11 +217,7 @@ You can also specify the TINYCLI_CONFIG environment variable.
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		if e, ok := err.(*errors.Error); ok && e == nil {
-			return
-		}
-
-		fmt.Fprintf(os.Stderr, "%+v\n", err)
+		errors.New(err).Exit()
 	}
 }
 

--- a/errors/error.go
+++ b/errors/error.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -166,4 +167,15 @@ func (e *Error) Contains(err interface{}) bool {
 	}
 
 	return false
+}
+
+// Exit exits the program leveraging the error for output before exiting with
+// error code 1. If DEBUG is set, it will output a stack trace.
+func (e *Error) Exit() {
+	if os.Getenv("DEBUG") != "" {
+		fmt.Fprintf(os.Stderr, "%+v\n", e)
+	} else {
+		fmt.Fprintln(os.Stderr, e)
+	}
+	os.Exit(1)
 }


### PR DESCRIPTION
This unifies error reporting after the program is ready to exit inside
the errors library.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>