### PR TITLE
 Support for finished channels, grpc tracing

### DIFF
--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tinyci/ci-agents/config"
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/urfave/cli"
-	"google.golang.org/grpc"
 )
 
 // Version is the version of this service.
@@ -60,10 +59,15 @@ func serve(ctx *cli.Context) error {
 		return transportErr
 	}
 
-	s := grpc.NewServer()
+	s, closer, err := h.CreateServer()
+	if err != nil {
+		return err
+	}
+
 	asset.RegisterAssetServer(s, &processors.AssetServer{H: h})
 
-	doneChan, err := h.Boot(t, s)
+	finished := make(chan struct{})
+	doneChan, err := h.Boot(t, s, finished)
 	if err != nil {
 		return err
 	}
@@ -72,6 +76,8 @@ func serve(ctx *cli.Context) error {
 	go func() {
 		<-sigChan
 		close(doneChan)
+		<-finished
+		closer.Close()
 		os.Exit(0)
 	}()
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)

--- a/cmd/datasvc/main.go
+++ b/cmd/datasvc/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tinyci/ci-agents/config"
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/urfave/cli"
-	"google.golang.org/grpc"
 )
 
 // Version is the version of this service.
@@ -62,10 +61,15 @@ func serve(ctx *cli.Context) error {
 		return transportErr
 	}
 
-	s := grpc.NewServer()
+	s, closer, err := h.CreateServer()
+	if err != nil {
+		return err
+	}
+
 	data.RegisterDataServer(s, &processors.DataServer{H: h})
 
-	doneChan, err := h.Boot(t, s)
+	finished := make(chan struct{})
+	doneChan, err := h.Boot(t, s, finished)
 	if err != nil {
 		return err
 	}
@@ -74,6 +78,8 @@ func serve(ctx *cli.Context) error {
 	go func() {
 		<-sigChan
 		close(doneChan)
+		<-finished
+		closer.Close()
 		os.Exit(0)
 	}()
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)

--- a/cmd/logsvc/main.go
+++ b/cmd/logsvc/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tinyci/ci-agents/config"
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/urfave/cli"
-	"google.golang.org/grpc"
 )
 
 // Version is the version of this service.
@@ -60,10 +59,15 @@ func serve(ctx *cli.Context) error {
 		return transportErr
 	}
 
-	s := grpc.NewServer()
+	s, closer, err := h.CreateServer()
+	if err != nil {
+		return err
+	}
+
 	log.RegisterLogServer(s, processors.New(nil))
 
-	doneChan, err := h.Boot(t, s)
+	finished := make(chan struct{})
+	doneChan, err := h.Boot(t, s, finished)
 	if err != nil {
 		return err
 	}
@@ -72,6 +76,8 @@ func serve(ctx *cli.Context) error {
 	go func() {
 		<-sigChan
 		close(doneChan)
+		<-finished
+		closer.Close()
 		os.Exit(0)
 	}()
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.1.3
+	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/jinzhu/gorm v1.9.2
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a // indirect
 	github.com/jinzhu/now v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+
 github.com/gorilla/sessions v1.1.1/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
 github.com/gorilla/sessions v1.1.3 h1:uXoZdcdA5XdXF3QzuSlheVRUvjl+1rKY7zBXL68L9RU=
 github.com/gorilla/sessions v1.1.3/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
+github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 h1:MJG/KsmcqMwFAkh8mTnAwhyKoB+sTAnY4CACC110tbU=
+github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
 github.com/jinzhu/gorm v1.9.2 h1:lCvgEaqe/HVE+tjAR2mt4HbbHAZsQOv3XAZiEZV37iw=
 github.com/jinzhu/gorm v1.9.2/go.mod h1:Vla75njaFJ8clLU1W44h34PjIkijhjHIYnZxMqCdxqo=
 github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a h1:eeaG9XMUvRBYXJi4pg1ZKM7nxc5AfXfojeLLW7O5J3k=

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -28,8 +28,6 @@ import (
 	"golang.org/x/net/websocket"
 	"golang.org/x/oauth2"
 
-	jaegercfg "github.com/uber/jaeger-client-go/config"
-
 	gh "github.com/google/go-github/github"
 )
 
@@ -284,23 +282,7 @@ func (h *H) NewTracingSpan(ctx *gin.Context, operation string) opentracing.Span 
 }
 
 func (h *H) createGlobalTracer() (io.Closer, *errors.Error) {
-	// FIXME Taken from jaeger/opentracing examples; needs tunables.
-	cfg, err := jaegercfg.FromEnv()
-	if err != nil {
-		return nil, errors.New(err)
-	}
-
-	cfg.Sampler = &jaegercfg.SamplerConfig{
-		Type:  "const",
-		Param: 1,
-	}
-
-	closer, err := cfg.InitGlobalTracer("uisvc")
-	if err != nil {
-		return nil, errors.New(err)
-	}
-
-	return closer, nil
+	return utils.CreateTracer("uisvc")
 }
 
 // Init initialize the handler and makes it available for requests.

--- a/testutil/testservers/servers.go
+++ b/testutil/testservers/servers.go
@@ -144,7 +144,7 @@ func MakeDataServer() (*handler.H, chan struct{}, *errors.Error) {
 	srv := grpc.NewServer()
 	data.RegisterDataServer(srv, &datasvc.DataServer{H: h})
 
-	doneChan, err := h.Boot(t, srv)
+	doneChan, err := h.Boot(t, srv, make(chan struct{}))
 	return h, doneChan, errors.New(err)
 }
 
@@ -168,7 +168,7 @@ func MakeAssetServer() (*handler.H, chan struct{}, *errors.Error) {
 	srv := grpc.NewServer()
 	asset.RegisterAssetServer(srv, &assetsvc.AssetServer{H: h})
 
-	doneChan, err := h.Boot(t, srv)
+	doneChan, err := h.Boot(t, srv, make(chan struct{}))
 	return h, doneChan, errors.New(err)
 }
 
@@ -198,7 +198,7 @@ func MakeQueueServer() (*handler.H, chan struct{}, *errors.Error) {
 	srv := grpc.NewServer()
 	queue.RegisterQueueServer(srv, &queuesvc.QueueServer{H: h})
 
-	doneChan, err := h.Boot(t, srv)
+	doneChan, err := h.Boot(t, srv, make(chan struct{}))
 	return h, doneChan, errors.New(err)
 }
 
@@ -284,6 +284,6 @@ func MakeLogServer() (*handler.H, chan struct{}, *LogJournal, *errors.Error) {
 	srv := grpc.NewServer()
 	log.RegisterLogServer(srv, logsvc.New(logDispatch))
 
-	doneChan, err := h.Boot(t, srv)
+	doneChan, err := h.Boot(t, srv, make(chan struct{}))
 	return h, doneChan, journal, errors.New(err)
 }

--- a/utils/tracer.go
+++ b/utils/tracer.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"io"
+
+	"github.com/tinyci/ci-agents/errors"
+	"github.com/uber/jaeger-client-go/config"
+)
+
+// CreateTracer creates an opentracing-compatible jaegertracing client.
+func CreateTracer(serviceName string) (io.Closer, *errors.Error) {
+	// FIXME Taken from jaeger/opentracing examples; needs tunables.
+	cfg, err := config.FromEnv()
+	if err != nil {
+		return nil, errors.New(err)
+	}
+
+	cfg.Sampler = &config.SamplerConfig{
+		Type:  "const",
+		Param: 1,
+	}
+
+	closer, err := cfg.InitGlobalTracer(serviceName)
+	if err != nil {
+		return nil, errors.New(err)
+	}
+
+	return closer, nil
+}

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/LICENSE
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2016, gRPC Ecosystem
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of grpc-opentracing nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/PATENTS
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/PATENTS
@@ -1,0 +1,23 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the GRPC project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of GRPC, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of GRPC.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of GRPC or any code incorporated within this
+implementation of GRPC constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of GRPC
+shall terminate as of the date such litigation is filed.
+Status API Training Shop Blog About

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/README.md
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/README.md
@@ -1,0 +1,57 @@
+# OpenTracing support for gRPC in Go
+
+The `otgrpc` package makes it easy to add OpenTracing support to gRPC-based
+systems in Go.
+
+## Installation
+
+```
+go get github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc
+```
+
+## Documentation
+
+See the basic usage examples below and the [package documentation on
+godoc.org](https://godoc.org/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc).
+
+## Client-side usage example
+
+Wherever you call `grpc.Dial`:
+
+```go
+// You must have some sort of OpenTracing Tracer instance on hand.
+var tracer opentracing.Tracer = ...
+...
+
+// Set up a connection to the server peer.
+conn, err := grpc.Dial(
+    address,
+    ... // other options
+    grpc.WithUnaryInterceptor(
+        otgrpc.OpenTracingClientInterceptor(tracer)),
+    grpc.WithStreamInterceptor(
+        otgrpc.OpenTracingStreamClientInterceptor(tracer)))
+
+// All future RPC activity involving `conn` will be automatically traced.
+```
+
+## Server-side usage example
+
+Wherever you call `grpc.NewServer`:
+
+```go
+// You must have some sort of OpenTracing Tracer instance on hand.
+var tracer opentracing.Tracer = ...
+...
+
+// Initialize the gRPC server.
+s := grpc.NewServer(
+    ... // other options
+    grpc.UnaryInterceptor(
+        otgrpc.OpenTracingServerInterceptor(tracer)),
+    grpc.StreamInterceptor(
+        otgrpc.OpenTracingStreamServerInterceptor(tracer)))
+
+// All future RPC activity involving `s` will be automatically traced.
+```
+

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/client.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/client.go
@@ -1,0 +1,239 @@
+package otgrpc
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"io"
+	"runtime"
+	"sync/atomic"
+)
+
+// OpenTracingClientInterceptor returns a grpc.UnaryClientInterceptor suitable
+// for use in a grpc.Dial call.
+//
+// For example:
+//
+//     conn, err := grpc.Dial(
+//         address,
+//         ...,  // (existing DialOptions)
+//         grpc.WithUnaryInterceptor(otgrpc.OpenTracingClientInterceptor(tracer)))
+//
+// All gRPC client spans will inject the OpenTracing SpanContext into the gRPC
+// metadata; they will also look in the context.Context for an active
+// in-process parent Span and establish a ChildOf reference if such a parent
+// Span could be found.
+func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option) grpc.UnaryClientInterceptor {
+	otgrpcOpts := newOptions()
+	otgrpcOpts.apply(optFuncs...)
+	return func(
+		ctx context.Context,
+		method string,
+		req, resp interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		var err error
+		var parentCtx opentracing.SpanContext
+		if parent := opentracing.SpanFromContext(ctx); parent != nil {
+			parentCtx = parent.Context()
+		}
+		if otgrpcOpts.inclusionFunc != nil &&
+			!otgrpcOpts.inclusionFunc(parentCtx, method, req, resp) {
+			return invoker(ctx, method, req, resp, cc, opts...)
+		}
+		clientSpan := tracer.StartSpan(
+			method,
+			opentracing.ChildOf(parentCtx),
+			ext.SpanKindRPCClient,
+			gRPCComponentTag,
+		)
+		defer clientSpan.Finish()
+		ctx = injectSpanContext(ctx, tracer, clientSpan)
+		if otgrpcOpts.logPayloads {
+			clientSpan.LogFields(log.Object("gRPC request", req))
+		}
+		err = invoker(ctx, method, req, resp, cc, opts...)
+		if err == nil {
+			if otgrpcOpts.logPayloads {
+				clientSpan.LogFields(log.Object("gRPC response", resp))
+			}
+		} else {
+			SetSpanTags(clientSpan, err, true)
+			clientSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
+		}
+		if otgrpcOpts.decorator != nil {
+			otgrpcOpts.decorator(clientSpan, method, req, resp, err)
+		}
+		return err
+	}
+}
+
+// OpenTracingStreamClientInterceptor returns a grpc.StreamClientInterceptor suitable
+// for use in a grpc.Dial call. The interceptor instruments streaming RPCs by creating
+// a single span to correspond to the lifetime of the RPC's stream.
+//
+// For example:
+//
+//     conn, err := grpc.Dial(
+//         address,
+//         ...,  // (existing DialOptions)
+//         grpc.WithStreamInterceptor(otgrpc.OpenTracingStreamClientInterceptor(tracer)))
+//
+// All gRPC client spans will inject the OpenTracing SpanContext into the gRPC
+// metadata; they will also look in the context.Context for an active
+// in-process parent Span and establish a ChildOf reference if such a parent
+// Span could be found.
+func OpenTracingStreamClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option) grpc.StreamClientInterceptor {
+	otgrpcOpts := newOptions()
+	otgrpcOpts.apply(optFuncs...)
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		var err error
+		var parentCtx opentracing.SpanContext
+		if parent := opentracing.SpanFromContext(ctx); parent != nil {
+			parentCtx = parent.Context()
+		}
+		if otgrpcOpts.inclusionFunc != nil &&
+			!otgrpcOpts.inclusionFunc(parentCtx, method, nil, nil) {
+			return streamer(ctx, desc, cc, method, opts...)
+		}
+
+		clientSpan := tracer.StartSpan(
+			method,
+			opentracing.ChildOf(parentCtx),
+			ext.SpanKindRPCClient,
+			gRPCComponentTag,
+		)
+		ctx = injectSpanContext(ctx, tracer, clientSpan)
+		cs, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			clientSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
+			SetSpanTags(clientSpan, err, true)
+			clientSpan.Finish()
+			return cs, err
+		}
+		return newOpenTracingClientStream(cs, method, desc, clientSpan, otgrpcOpts), nil
+	}
+}
+
+func newOpenTracingClientStream(cs grpc.ClientStream, method string, desc *grpc.StreamDesc, clientSpan opentracing.Span, otgrpcOpts *options) grpc.ClientStream {
+	finishChan := make(chan struct{})
+
+	isFinished := new(int32)
+	*isFinished = 0
+	finishFunc := func(err error) {
+		// The current OpenTracing specification forbids finishing a span more than
+		// once. Since we have multiple code paths that could concurrently call
+		// `finishFunc`, we need to add some sort of synchronization to guard against
+		// multiple finishing.
+		if !atomic.CompareAndSwapInt32(isFinished, 0, 1) {
+			return
+		}
+		close(finishChan)
+		defer clientSpan.Finish()
+		if err != nil {
+			clientSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
+			SetSpanTags(clientSpan, err, true)
+		}
+		if otgrpcOpts.decorator != nil {
+			otgrpcOpts.decorator(clientSpan, method, nil, nil, err)
+		}
+	}
+	go func() {
+		select {
+		case <-finishChan:
+			// The client span is being finished by another code path; hence, no
+			// action is necessary.
+		case <-cs.Context().Done():
+			finishFunc(cs.Context().Err())
+		}
+	}()
+	otcs := &openTracingClientStream{
+		ClientStream: cs,
+		desc:         desc,
+		finishFunc:   finishFunc,
+	}
+
+	// The `ClientStream` interface allows one to omit calling `Recv` if it's
+	// known that the result will be `io.EOF`. See
+	// http://stackoverflow.com/q/42915337
+	// In such cases, there's nothing that triggers the span to finish. We,
+	// therefore, set a finalizer so that the span and the context goroutine will
+	// at least be cleaned up when the garbage collector is run.
+	runtime.SetFinalizer(otcs, func(otcs *openTracingClientStream) {
+		otcs.finishFunc(nil)
+	})
+	return otcs
+}
+
+type openTracingClientStream struct {
+	grpc.ClientStream
+	desc       *grpc.StreamDesc
+	finishFunc func(error)
+}
+
+func (cs *openTracingClientStream) Header() (metadata.MD, error) {
+	md, err := cs.ClientStream.Header()
+	if err != nil {
+		cs.finishFunc(err)
+	}
+	return md, err
+}
+
+func (cs *openTracingClientStream) SendMsg(m interface{}) error {
+	err := cs.ClientStream.SendMsg(m)
+	if err != nil {
+		cs.finishFunc(err)
+	}
+	return err
+}
+
+func (cs *openTracingClientStream) RecvMsg(m interface{}) error {
+	err := cs.ClientStream.RecvMsg(m)
+	if err == io.EOF {
+		cs.finishFunc(nil)
+		return err
+	} else if err != nil {
+		cs.finishFunc(err)
+		return err
+	}
+	if !cs.desc.ServerStreams {
+		cs.finishFunc(nil)
+	}
+	return err
+}
+
+func (cs *openTracingClientStream) CloseSend() error {
+	err := cs.ClientStream.CloseSend()
+	if err != nil {
+		cs.finishFunc(err)
+	}
+	return err
+}
+
+func injectSpanContext(ctx context.Context, tracer opentracing.Tracer, clientSpan opentracing.Span) context.Context {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	} else {
+		md = md.Copy()
+	}
+	mdWriter := metadataReaderWriter{md}
+	err := tracer.Inject(clientSpan.Context(), opentracing.HTTPHeaders, mdWriter)
+	// We have no better place to record an error than the Span itself :-/
+	if err != nil {
+		clientSpan.LogFields(log.String("event", "Tracer.Inject() failed"), log.Error(err))
+	}
+	return metadata.NewOutgoingContext(ctx, md)
+}

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/errors.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/errors.go
@@ -1,0 +1,69 @@
+package otgrpc
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// A Class is a set of types of outcomes (including errors) that will often
+// be handled in the same way.
+type Class string
+
+const (
+	Unknown Class = "0xx"
+	// Success represents outcomes that achieved the desired results.
+	Success Class = "2xx"
+	// ClientError represents errors that were the client's fault.
+	ClientError Class = "4xx"
+	// ServerError represents errors that were the server's fault.
+	ServerError Class = "5xx"
+)
+
+// ErrorClass returns the class of the given error
+func ErrorClass(err error) Class {
+	if s, ok := status.FromError(err); ok {
+		switch s.Code() {
+		// Success or "success"
+		case codes.OK, codes.Canceled:
+			return Success
+
+		// Client errors
+		case codes.InvalidArgument, codes.NotFound, codes.AlreadyExists,
+			codes.PermissionDenied, codes.Unauthenticated, codes.FailedPrecondition,
+			codes.OutOfRange:
+			return ClientError
+
+		// Server errors
+		case codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted,
+			codes.Unimplemented, codes.Internal, codes.Unavailable, codes.DataLoss:
+			return ServerError
+
+		// Not sure
+		case codes.Unknown:
+			fallthrough
+		default:
+			return Unknown
+		}
+	}
+	return Unknown
+}
+
+// SetSpanTags sets one or more tags on the given span according to the
+// error.
+func SetSpanTags(span opentracing.Span, err error, client bool) {
+	c := ErrorClass(err)
+	code := codes.Unknown
+	if s, ok := status.FromError(err); ok {
+		code = s.Code()
+	}
+	span.SetTag("response_code", code)
+	span.SetTag("response_class", c)
+	if err == nil {
+		return
+	}
+	if client || c == ServerError {
+		ext.Error.Set(span, true)
+	}
+}

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/options.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/options.go
@@ -1,0 +1,76 @@
+package otgrpc
+
+import "github.com/opentracing/opentracing-go"
+
+// Option instances may be used in OpenTracing(Server|Client)Interceptor
+// initialization.
+//
+// See this post about the "functional options" pattern:
+// http://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
+type Option func(o *options)
+
+// LogPayloads returns an Option that tells the OpenTracing instrumentation to
+// try to log application payloads in both directions.
+func LogPayloads() Option {
+	return func(o *options) {
+		o.logPayloads = true
+	}
+}
+
+// SpanInclusionFunc provides an optional mechanism to decide whether or not
+// to trace a given gRPC call. Return true to create a Span and initiate
+// tracing, false to not create a Span and not trace.
+//
+// parentSpanCtx may be nil if no parent could be extraction from either the Go
+// context.Context (on the client) or the RPC (on the server).
+type SpanInclusionFunc func(
+	parentSpanCtx opentracing.SpanContext,
+	method string,
+	req, resp interface{}) bool
+
+// IncludingSpans binds a IncludeSpanFunc to the options
+func IncludingSpans(inclusionFunc SpanInclusionFunc) Option {
+	return func(o *options) {
+		o.inclusionFunc = inclusionFunc
+	}
+}
+
+// SpanDecoratorFunc provides an (optional) mechanism for otgrpc users to add
+// arbitrary tags/logs/etc to the opentracing.Span associated with client
+// and/or server RPCs.
+type SpanDecoratorFunc func(
+	span opentracing.Span,
+	method string,
+	req, resp interface{},
+	grpcError error)
+
+// SpanDecorator binds a function that decorates gRPC Spans.
+func SpanDecorator(decorator SpanDecoratorFunc) Option {
+	return func(o *options) {
+		o.decorator = decorator
+	}
+}
+
+// The internal-only options struct. Obviously overkill at the moment; but will
+// scale well as production use dictates other configuration and tuning
+// parameters.
+type options struct {
+	logPayloads bool
+	decorator   SpanDecoratorFunc
+	// May be nil.
+	inclusionFunc SpanInclusionFunc
+}
+
+// newOptions returns the default options.
+func newOptions() *options {
+	return &options{
+		logPayloads:   false,
+		inclusionFunc: nil,
+	}
+}
+
+func (o *options) apply(opts ...Option) {
+	for _, opt := range opts {
+		opt(o)
+	}
+}

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/package.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/package.go
@@ -1,0 +1,5 @@
+// Package otgrpc provides OpenTracing support for any gRPC client or server.
+//
+// See the README for simple usage examples:
+// https://github.com/grpc-ecosystem/grpc-opentracing/blob/master/go/otgrpc/README.md
+package otgrpc

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/server.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/server.go
@@ -1,0 +1,141 @@
+package otgrpc
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// OpenTracingServerInterceptor returns a grpc.UnaryServerInterceptor suitable
+// for use in a grpc.NewServer call.
+//
+// For example:
+//
+//     s := grpc.NewServer(
+//         ...,  // (existing ServerOptions)
+//         grpc.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(tracer)))
+//
+// All gRPC server spans will look for an OpenTracing SpanContext in the gRPC
+// metadata; if found, the server span will act as the ChildOf that RPC
+// SpanContext.
+//
+// Root or not, the server Span will be embedded in the context.Context for the
+// application-specific gRPC handler(s) to access.
+func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option) grpc.UnaryServerInterceptor {
+	otgrpcOpts := newOptions()
+	otgrpcOpts.apply(optFuncs...)
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp interface{}, err error) {
+		spanContext, err := extractSpanContext(ctx, tracer)
+		if err != nil && err != opentracing.ErrSpanContextNotFound {
+			// TODO: establish some sort of error reporting mechanism here. We
+			// don't know where to put such an error and must rely on Tracer
+			// implementations to do something appropriate for the time being.
+		}
+		if otgrpcOpts.inclusionFunc != nil &&
+			!otgrpcOpts.inclusionFunc(spanContext, info.FullMethod, req, nil) {
+			return handler(ctx, req)
+		}
+		serverSpan := tracer.StartSpan(
+			info.FullMethod,
+			ext.RPCServerOption(spanContext),
+			gRPCComponentTag,
+		)
+		defer serverSpan.Finish()
+
+		ctx = opentracing.ContextWithSpan(ctx, serverSpan)
+		if otgrpcOpts.logPayloads {
+			serverSpan.LogFields(log.Object("gRPC request", req))
+		}
+		resp, err = handler(ctx, req)
+		if err == nil {
+			if otgrpcOpts.logPayloads {
+				serverSpan.LogFields(log.Object("gRPC response", resp))
+			}
+		} else {
+			SetSpanTags(serverSpan, err, false)
+			serverSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
+		}
+		if otgrpcOpts.decorator != nil {
+			otgrpcOpts.decorator(serverSpan, info.FullMethod, req, resp, err)
+		}
+		return resp, err
+	}
+}
+
+// OpenTracingStreamServerInterceptor returns a grpc.StreamServerInterceptor suitable
+// for use in a grpc.NewServer call. The interceptor instruments streaming RPCs by
+// creating a single span to correspond to the lifetime of the RPC's stream.
+//
+// For example:
+//
+//     s := grpc.NewServer(
+//         ...,  // (existing ServerOptions)
+//         grpc.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(tracer)))
+//
+// All gRPC server spans will look for an OpenTracing SpanContext in the gRPC
+// metadata; if found, the server span will act as the ChildOf that RPC
+// SpanContext.
+//
+// Root or not, the server Span will be embedded in the context.Context for the
+// application-specific gRPC handler(s) to access.
+func OpenTracingStreamServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option) grpc.StreamServerInterceptor {
+	otgrpcOpts := newOptions()
+	otgrpcOpts.apply(optFuncs...)
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		spanContext, err := extractSpanContext(ss.Context(), tracer)
+		if err != nil && err != opentracing.ErrSpanContextNotFound {
+			// TODO: establish some sort of error reporting mechanism here. We
+			// don't know where to put such an error and must rely on Tracer
+			// implementations to do something appropriate for the time being.
+		}
+		if otgrpcOpts.inclusionFunc != nil &&
+			!otgrpcOpts.inclusionFunc(spanContext, info.FullMethod, nil, nil) {
+			return handler(srv, ss)
+		}
+
+		serverSpan := tracer.StartSpan(
+			info.FullMethod,
+			ext.RPCServerOption(spanContext),
+			gRPCComponentTag,
+		)
+		defer serverSpan.Finish()
+		ss = &openTracingServerStream{
+			ServerStream: ss,
+			ctx:          opentracing.ContextWithSpan(ss.Context(), serverSpan),
+		}
+		err = handler(srv, ss)
+		if err != nil {
+			SetSpanTags(serverSpan, err, false)
+			serverSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
+		}
+		if otgrpcOpts.decorator != nil {
+			otgrpcOpts.decorator(serverSpan, info.FullMethod, nil, nil, err)
+		}
+		return err
+	}
+}
+
+type openTracingServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (ss *openTracingServerStream) Context() context.Context {
+	return ss.ctx
+}
+
+func extractSpanContext(ctx context.Context, tracer opentracing.Tracer) (opentracing.SpanContext, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	}
+	return tracer.Extract(opentracing.HTTPHeaders, metadataReaderWriter{md})
+}

--- a/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/shared.go
+++ b/vendor/github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc/shared.go
@@ -1,0 +1,42 @@
+package otgrpc
+
+import (
+	"strings"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"google.golang.org/grpc/metadata"
+)
+
+var (
+	// Morally a const:
+	gRPCComponentTag = opentracing.Tag{string(ext.Component), "gRPC"}
+)
+
+// metadataReaderWriter satisfies both the opentracing.TextMapReader and
+// opentracing.TextMapWriter interfaces.
+type metadataReaderWriter struct {
+	metadata.MD
+}
+
+func (w metadataReaderWriter) Set(key, val string) {
+	// The GRPC HPACK implementation rejects any uppercase keys here.
+	//
+	// As such, since the HTTP_HEADERS format is case-insensitive anyway, we
+	// blindly lowercase the key (which is guaranteed to work in the
+	// Inject/Extract sense per the OpenTracing spec).
+	key = strings.ToLower(key)
+	w.MD[key] = append(w.MD[key], val)
+}
+
+func (w metadataReaderWriter) ForeachKey(handler func(key, val string) error) error {
+	for k, vals := range w.MD {
+		for _, v := range vals {
+			if err := handler(k, v); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -72,6 +72,8 @@ github.com/gorilla/context
 github.com/gorilla/securecookie
 # github.com/gorilla/sessions v1.1.3
 github.com/gorilla/sessions
+# github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
+github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc
 # github.com/jinzhu/gorm v1.9.2
 github.com/jinzhu/gorm
 github.com/jinzhu/gorm/dialects/postgres
@@ -146,13 +148,13 @@ golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20190328230028-74de082e2cca
 golang.org/x/net/websocket
 golang.org/x/net/trace
+golang.org/x/net/context
 golang.org/x/net/internal/timeseries
 golang.org/x/net/http2
 golang.org/x/net/http2/hpack
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
 golang.org/x/net/idna
-golang.org/x/net/context
 # golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914
 golang.org/x/oauth2
 golang.org/x/oauth2/github


### PR DESCRIPTION
This adds the finished channel pattern to the grpc services as well.

It also integrates server-side opentracing by way of the jaegertracing
client. Client support still needs to be integrated.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
