### PR TITLE
box-release.rb: install ca-certificates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ci-gen"]
-	path = ci-gen
-	url = https://github.com/tinyci/ci-gen

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,9 @@
 (C) 2018, 2019 Erik Hollensbe, Josiah Kiehl, Haoqi "Eric" Zhu, Razvan "Cristian" Staretu.
 
+The following license text applies to all but the following directories (Which have their own license):
+
+- `ci-gen`
+
 This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 If a copy of the MPL was not distributed with this file, You can obtain
 one at https://mozilla.org/MPL/2.0/.

--- a/box-release.rb
+++ b/box-release.rb
@@ -2,6 +2,8 @@ from "ubuntu:latest"
 
 after { flatten }
 
+skip { run "apt update -qq" }
+run "apt install ca-certificates -y"
 copy "tinyci-#{getenv("VERSION")}.tar.gz", "/tinyci-release.tar.gz"
 run "touch /tinyci-#{getenv("VERSION")}"
 run "tar --no-same-owner --strip-components 1 -xvz -C /usr/local/bin -f /tinyci-release.tar.gz"


### PR DESCRIPTION
This doesn't get installed in the release image ATM; caused some issues
talking to github.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>