### PR TITLE
Fix enable/disable tracing in ci-gen/grpc handlers

### DIFF
--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -77,7 +77,9 @@ func serve(ctx *cli.Context) error {
 		<-sigChan
 		close(doneChan)
 		<-finished
-		closer.Close()
+		if closer != nil {
+			closer.Close()
+		}
 		os.Exit(0)
 	}()
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)

--- a/cmd/datasvc/main.go
+++ b/cmd/datasvc/main.go
@@ -79,7 +79,9 @@ func serve(ctx *cli.Context) error {
 		<-sigChan
 		close(doneChan)
 		<-finished
-		closer.Close()
+		if closer != nil {
+			closer.Close()
+		}
 		os.Exit(0)
 	}()
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)

--- a/cmd/logsvc/main.go
+++ b/cmd/logsvc/main.go
@@ -77,7 +77,9 @@ func serve(ctx *cli.Context) error {
 		<-sigChan
 		close(doneChan)
 		<-finished
-		closer.Close()
+		if closer != nil {
+			closer.Close()
+		}
 		os.Exit(0)
 	}()
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)

--- a/cmd/queuesvc/main.go
+++ b/cmd/queuesvc/main.go
@@ -77,7 +77,9 @@ func serve(ctx *cli.Context) error {
 		<-sigChan
 		close(doneChan)
 		<-finished
-		closer.Close()
+		if closer != nil {
+			closer.Close()
+		}
 		os.Exit(0)
 	}()
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)


### PR DESCRIPTION
This was not actually gated in the grpc services, so it was causing some
trouble.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>