### PR TITLE
In the event a submitted branch is a fork AND added to the db, process it directly.

### DIFF
--- a/api/datasvc/test/basic_test.go
+++ b/api/datasvc/test/basic_test.go
@@ -138,7 +138,7 @@ func (ds *datasvcSuite) TestRepositories(c *check.C) {
 		owner := testutil.RandString(8) + "_" + strconv.Itoa(i)
 		repo := testutil.RandString(8)
 		fullRepo := path.Join(owner, repo)
-		c.Assert(ds.client.MakeRepo(fullRepo, username, i%2 == 0), check.IsNil)
+		c.Assert(ds.client.MakeRepo(fullRepo, username, i%2 == 0, ""), check.IsNil)
 		repos = append(repos, fullRepo)
 	}
 
@@ -195,7 +195,7 @@ func (ds *datasvcSuite) TestSubscriptions(c *check.C) {
 		owner := testutil.RandString(8) + "_" + strconv.Itoa(i)
 		repo := testutil.RandString(8)
 		fullRepo := path.Join(owner, repo)
-		c.Assert(ds.client.MakeRepo(fullRepo, username, false), check.IsNil)
+		c.Assert(ds.client.MakeRepo(fullRepo, username, false, ""), check.IsNil)
 		repos = append(repos, fullRepo)
 	}
 
@@ -218,7 +218,7 @@ func (ds *datasvcSuite) TestSubscriptions(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(len(subs), check.Equals, 1)
 
-	c.Assert(ds.client.MakeRepo("erikh/private", username, true), check.IsNil)
+	c.Assert(ds.client.MakeRepo("erikh/private", username, true, ""), check.IsNil)
 	c.Assert(
 		ds.client.Client().AddSubscription(username2, "erikh/private"),
 		check.NotNil,
@@ -307,7 +307,7 @@ func (ds *datasvcSuite) TestRef(c *check.C) {
 
 	ownerName, repoName := testutil.RandString(8), testutil.RandString(8)
 
-	c.Assert(ds.client.MakeRepo(path.Join(ownerName, repoName), username, false), check.IsNil)
+	c.Assert(ds.client.MakeRepo(path.Join(ownerName, repoName), username, false, ""), check.IsNil)
 
 	repo, err := ds.client.Client().GetRepository(path.Join(ownerName, repoName))
 	c.Assert(err, check.IsNil)

--- a/api/queuesvc/test/basic_test.go
+++ b/api/queuesvc/test/basic_test.go
@@ -88,7 +88,7 @@ func (qs *queuesvcSuite) TestManualSubmissionOfAddedFork(c *check.C) {
 	}
 
 	c.Assert(qs.queuesvcClient.SetMockSubmissionOnFork(qs.getMock(), sub, "erikh/foobar", "be3d26c478991039e951097f2c99f56b55396940"), check.IsNil)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	c.Assert(qs.queuesvcClient.Client().Submit(ctx, sub), check.IsNil)
 	defer cancel()
 
@@ -106,7 +106,7 @@ func (qs *queuesvcSuite) TestManualSubmissionOfAddedFork(c *check.C) {
 	}
 
 	c.Assert(qs.queuesvcClient.SetMockSubmissionOnFork(qs.getMock(), sub, "erikh/foobar", "be3d26c478991039e951097f2c99f56b55396940"), check.IsNil)
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	c.Assert(qs.queuesvcClient.Client().Submit(ctx, sub), check.NotNil)
 	defer cancel()
 }

--- a/api/queuesvc/test/setup_test.go
+++ b/api/queuesvc/test/setup_test.go
@@ -42,8 +42,12 @@ func (qs *queuesvcSuite) SetUpTest(c *check.C) {
 	qs.dataHandler, qs.dataDoneChan, err = testservers.MakeDataServer()
 	c.Assert(err, check.IsNil)
 
-	qs.logHandler, qs.logDoneChan, _, err = testservers.MakeLogServer()
+	var lj *testservers.LogJournal
+
+	qs.logHandler, qs.logDoneChan, lj, err = testservers.MakeLogServer()
 	c.Assert(err, check.IsNil)
+
+	go lj.Tail()
 
 	qs.queueHandler, qs.queueDoneChan, err = testservers.MakeQueueServer()
 	c.Assert(err, check.IsNil)

--- a/api/uisvc/test/basic_test.go
+++ b/api/uisvc/test/basic_test.go
@@ -293,10 +293,10 @@ func (us *uisvcSuite) TestVisibility(c *check.C) {
 	_, err = us.datasvcClient.MakeUser("erikh-the-third")
 	c.Assert(err, check.IsNil)
 
-	c.Assert(us.datasvcClient.MakeRepo("not-erikh/private-test", "not-erikh", true), check.IsNil)
-	c.Assert(us.datasvcClient.MakeRepo("erikh/private-test", "erikh", true), check.IsNil)
-	c.Assert(us.datasvcClient.MakeRepo("erikh/public", "erikh", false), check.IsNil)
-	c.Assert(us.datasvcClient.MakeRepo("erikh-the-third/public", "erikh-the-third", false), check.IsNil)
+	c.Assert(us.datasvcClient.MakeRepo("not-erikh/private-test", "not-erikh", true, ""), check.IsNil)
+	c.Assert(us.datasvcClient.MakeRepo("erikh/private-test", "erikh", true, ""), check.IsNil)
+	c.Assert(us.datasvcClient.MakeRepo("erikh/public", "erikh", false, ""), check.IsNil)
+	c.Assert(us.datasvcClient.MakeRepo("erikh-the-third/public", "erikh-the-third", false, ""), check.IsNil)
 
 	repos, err := tc.Visible("")
 	c.Assert(err, check.IsNil)

--- a/testutil/cmd/tinyci-fixturegen/main.go
+++ b/testutil/cmd/tinyci-fixturegen/main.go
@@ -126,7 +126,7 @@ func (c *cmd) mkParents(users []*model.User) (model.RepositoryList, *errors.Erro
 	for i := rand.Intn(int(c.ctx.GlobalUint("repositories"))) + 1; i >= 0; i-- {
 		ou := users[rand.Intn(len(users))]
 		name := strings.Join([]string{c.getString(), c.getString()}, "/")
-		if err := c.dc.MakeRepo(name, ou.Username, c.ctx.GlobalBool("private")); err != nil {
+		if err := c.dc.MakeRepo(name, ou.Username, c.ctx.GlobalBool("private"), ""); err != nil {
 			return nil, err
 		}
 

--- a/testutil/testclients/datasvc.go
+++ b/testutil/testclients/datasvc.go
@@ -37,9 +37,16 @@ func (dc *DataClient) MakeUser(username string) (*model.User, *errors.Error) {
 }
 
 // MakeRepo saves a repo with name, owner, and private state.
-func (dc *DataClient) MakeRepo(fullRepo, owner string, private bool) *errors.Error {
+func (dc *DataClient) MakeRepo(fullRepo, owner string, private bool, forkOf string) *errors.Error {
 	repos := []interface{}{
 		map[string]interface{}{"full_name": fullRepo, "private": private},
+	}
+
+	if forkOf != "" {
+		repos[0].(map[string]interface{})["fork"] = true
+		repos[0].(map[string]interface{})["parent"] = map[string]interface{}{
+			"full_name": forkOf, "private": private,
+		}
 	}
 
 	ghRepos := []*github.Repository{}
@@ -61,7 +68,7 @@ func (dc *DataClient) MakeQueueItem() (*model.QueueItem, *errors.Error) {
 
 	parentRepoOwner, parentRepoName := testutil.RandString(8), testutil.RandString(8)
 	repoName := path.Join(parentRepoOwner, parentRepoName)
-	if err := dc.MakeRepo(repoName, username, false); err != nil {
+	if err := dc.MakeRepo(repoName, username, false, ""); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +79,7 @@ func (dc *DataClient) MakeQueueItem() (*model.QueueItem, *errors.Error) {
 
 	forkRepoOwner, forkRepoName := testutil.RandString(8), testutil.RandString(8)
 	forkName := path.Join(forkRepoOwner, forkRepoName)
-	if err := dc.MakeRepo(forkName, username, false); err != nil {
+	if err := dc.MakeRepo(forkName, username, false, repoName); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This change is a little weird. Basically, if you take a parent, fork it,
and then add the *fork* to tinyCI, it would break submitting because it
was trying to resolve the parent, which may not belong to the user.

It was behaving properly, but in the event the fork was submitted
manually, it should behave like an added repository.

There's probably a few bugs that I haven't caught yet on this feature. I
hope to suss them out soon.

I also added liberal logging to the queue submission in a vain attempt
to figure out why my mocks weren't working, but they seem to add a
little useful tracing data so I'm keeping them for now until real
tracing arrives for real.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>