### PR TITLE
order runs for a given task by run id descending

### DIFF
--- a/model/task_runs.go
+++ b/model/task_runs.go
@@ -14,7 +14,7 @@ func (m *Model) GetRunsForTask(id, page, perPage int64) ([]*Run, *errors.Error) 
 		return nil, err
 	}
 
-	if err := m.Model(&Run{}).Limit(perPage).Offset(page*perPage).Where("task_id = ?", id).Find(&runs).Error; err != nil {
+	if err := m.Model(&Run{}).Order("id DESC").Limit(perPage).Offset(page*perPage).Where("task_id = ?", id).Find(&runs).Error; err != nil {
 		return nil, errors.New(err)
 	}
 

--- a/model/task_runs_test.go
+++ b/model/task_runs_test.go
@@ -92,9 +92,14 @@ func (ms *modelSuite) TestRunsForTask(c *check.C) {
 		newRuns, err := ms.model.GetRunsForTask(task, 0, 100)
 		c.Assert(err, check.IsNil)
 		c.Assert(len(newRuns), check.Equals, int(x))
+		var lastRunID int64
 		for _, run := range newRuns {
 			c.Assert(runs[run.Name], check.NotNil)
 			c.Assert(run.Task.ID, check.Equals, task)
+			if lastRunID > 0 {
+				c.Assert(run.ID < lastRunID, check.Equals, true)
+				lastRunID = run.ID
+			}
 		}
 	}
 	fmt.Printf("duration: %v\n", time.Since(now))


### PR DESCRIPTION
This was displaying in the insert order otherwise.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>