### PR TITLE
Improve task list performance in UI

### DIFF
--- a/migrations/tinyci/1.sql
+++ b/migrations/tinyci/1.sql
@@ -1,0 +1,7 @@
+create index users_username_idx on users (id, username);
+--
+create index user_errors_user_id_idx on user_errors (id, user_id);
+--
+create index session_key_expires_idx on sessions (key, expires_on);
+--
+create index runs_task_idx on runs (id, task_id);


### PR DESCRIPTION
The AfterFind hook was reaping a separate run count for each row
selected, instead of aggregating the result in a single query. This was
unsurprisingly expensive.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>