### PR TITLE
cmd/tinycli/main.go: remove warning and correct predicate

### DIFF
--- a/cmd/tinycli/main.go
+++ b/cmd/tinycli/main.go
@@ -49,8 +49,7 @@ func getCert(ctx *cli.Context) (*transport.Cert, *errors.Error) {
 		ctx.GlobalString("cert"),
 		ctx.GlobalString("key")
 
-	if ca == "" || certStr == "" || keyStr == "" {
-		fmt.Fprintln(os.Stderr, "TLS parameters not provided, using plaintext or standard TLS")
+	if ca == "" && certStr == "" && keyStr == "" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
The warnings were spammy for someone who had configured TLS with a
certificate chain in the trust store for no good reason. Now, for the
manually-programmed case it will just error from the cert load.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>