### PR TITLE
Fix situations where tasks could not be canceled via submission

### DIFF
--- a/model/submission.go
+++ b/model/submission.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/jinzhu/gorm"
@@ -386,7 +387,8 @@ func (m *Model) CancelSubmissionByID(id int64, baseURL string, client github.Cli
 
 	for _, task := range tasks {
 		if err := m.CancelTaskByID(task.ID, baseURL, client); err != nil {
-			return err
+			// we want to skip returning this error so all tasks have the chance to be canceled.
+			fmt.Println(err) // FIXME can't log here. need to fix that.
 		}
 	}
 

--- a/model/submission_test.go
+++ b/model/submission_test.go
@@ -289,6 +289,8 @@ func (ms *modelSuite) TestSubmissionTasks(c *check.C) {
 					}
 				}
 
+				// checking that we can cancel submissions with canceled tasks in them
+				c.Assert(ms.model.CancelTask(tasks[0], "", gh), check.IsNil)
 				c.Assert(ms.model.CancelSubmissionByID(subID, "", gh), check.IsNil)
 
 				for i := int64(0); i < 2; i++ {


### PR DESCRIPTION
This was because the run was already finished for some reason. Now we're
just skipping errors.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>

closes #121 