### PR TITLE
Add route mapping

### DIFF
--- a/api/assetsvc/setup_test.go
+++ b/api/assetsvc/setup_test.go
@@ -8,6 +8,7 @@ import (
 	check "github.com/erikh/check"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/handler"
 	client "github.com/tinyci/ci-agents/clients/asset"
+	"github.com/tinyci/ci-agents/config"
 )
 
 type assetsvcSuite struct {
@@ -28,7 +29,7 @@ func (as *assetsvcSuite) SetUpTest(c *check.C) {
 	as.assetsvcHandler, as.assetsvcDoneChan, err = MakeAssetServer()
 	c.Assert(err, check.IsNil)
 
-	as.assetClient, err = client.NewClient("localhost:6002", nil, false)
+	as.assetClient, err = client.NewClient(config.DefaultServices.Asset.String(), nil, false)
 	c.Assert(err, check.IsNil)
 }
 

--- a/api/assetsvc/testserver.go
+++ b/api/assetsvc/testserver.go
@@ -12,7 +12,7 @@ import (
 // MakeAssetServer makes an instance of the assetsvc on port 6000. It returns a
 // chan which can be closed to terminate it, and any boot-time errors.
 func MakeAssetServer() (*handler.H, chan struct{}, *errors.Error) {
-	t, err := transport.Listen(nil, "tcp", "localhost:6002")
+	t, err := transport.Listen(nil, "tcp", config.DefaultServices.Asset.String())
 	if err != nil {
 		return nil, nil, errors.New(err)
 	}

--- a/api/datasvc/testserver.go
+++ b/api/datasvc/testserver.go
@@ -29,7 +29,7 @@ func MakeDataServer() (*handler.H, chan struct{}, *errors.Error) {
 		},
 	}
 
-	t, err := transport.Listen(nil, "tcp", "localhost:6000")
+	t, err := transport.Listen(nil, "tcp", config.DefaultServices.Data.String())
 	if err != nil {
 		return nil, nil, errors.New(err)
 	}

--- a/api/logsvc/setup_test.go
+++ b/api/logsvc/setup_test.go
@@ -7,6 +7,7 @@ import (
 	check "github.com/erikh/check"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/handler"
 	client "github.com/tinyci/ci-agents/clients/log"
+	"github.com/tinyci/ci-agents/config"
 )
 
 type logsvcSuite struct {
@@ -26,7 +27,7 @@ func (ls *logsvcSuite) SetUpTest(c *check.C) {
 	ls.logsvcHandler, ls.logsvcDoneChan, ls.journal, err = MakeLogServer()
 	c.Assert(err, check.IsNil)
 
-	client.ConfigureRemote("localhost:6005", nil, false)
+	client.ConfigureRemote(config.DefaultServices.Log.String(), nil, false)
 }
 
 func (ls *logsvcSuite) TearDownTest(c *check.C) {

--- a/api/logsvc/testserver.go
+++ b/api/logsvc/testserver.go
@@ -39,7 +39,7 @@ func MakeLogServer() (*handler.H, chan struct{}, *LogJournal, *errors.Error) {
 		},
 	}
 
-	t, err := transport.Listen(nil, "tcp", "localhost:6005")
+	t, err := transport.Listen(nil, "tcp", config.DefaultServices.Log.String())
 	if err != nil {
 		return nil, nil, nil, errors.New(err)
 	}

--- a/api/queuesvc/testserver.go
+++ b/api/queuesvc/testserver.go
@@ -28,7 +28,7 @@ func MakeQueueServer() (*handler.H, chan struct{}, *errors.Error) {
 		},
 	}
 
-	t, err := transport.Listen(nil, "tcp", "localhost:6001")
+	t, err := transport.Listen(nil, "tcp", config.DefaultServices.Queue.String())
 	if err != nil {
 		return nil, nil, errors.New(err)
 	}

--- a/api/uisvc/restapi/setup_test.go
+++ b/api/uisvc/restapi/setup_test.go
@@ -65,7 +65,7 @@ func (us *uisvcSuite) SetUpTest(c *check.C) {
 	us.queuesvcClient, err = testclients.NewQueueClient(us.datasvcClient)
 	c.Assert(err, check.IsNil)
 
-	us.assetsvcClient, err = asset.NewClient("localhost:6002", nil, false)
+	us.assetsvcClient, err = asset.NewClient(config.DefaultServices.Asset.String(), nil, false)
 	c.Assert(err, check.IsNil)
 
 	us.oauthDoneChan, err = testservers.BootOAuthService()

--- a/api/uisvc/restapi/testserver.go
+++ b/api/uisvc/restapi/testserver.go
@@ -38,7 +38,7 @@ func MakeUIServer(client github.Client) (*handlers.H, chan struct{}, *tinyci.Cli
 		},
 	}
 
-	d, err := data.New("localhost:6000", nil, false)
+	d, err := data.New(config.DefaultServices.Data.String(), nil, false)
 	if err != nil {
 		return nil, nil, nil, nil, errors.New(err)
 	}
@@ -66,7 +66,7 @@ func MakeUIServer(client github.Client) (*handlers.H, chan struct{}, *tinyci.Cli
 		return nil, nil, nil, nil, err
 	}
 
-	tc, err := tinyci.New("http://localhost:6010", token, nil)
+	tc, err := tinyci.New(config.DefaultServices.UI.String(), token, nil)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -85,7 +85,7 @@ func MakeUIServer(client github.Client) (*handlers.H, chan struct{}, *tinyci.Cli
 		return nil, nil, nil, nil, err
 	}
 
-	utc, err := tinyci.New("http://localhost:6010", token, nil)
+	utc, err := tinyci.New(config.DefaultServices.UI.String(), token, nil)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -54,7 +54,7 @@ func serve(ctx *cli.Context) error {
 		return certErr
 	}
 
-	t, transportErr := transport.Listen(cert, "tcp", fmt.Sprintf(":%d", 6002)) // FIXME parameterize
+	t, transportErr := transport.Listen(cert, "tcp", fmt.Sprintf(":%d", config.DefaultServices.Asset.Port)) // FIXME parameterize
 	if transportErr != nil {
 		return transportErr
 	}

--- a/cmd/cancelbot/main.go
+++ b/cmd/cancelbot/main.go
@@ -8,6 +8,7 @@ import (
 	transport "github.com/erikh/go-transport"
 	"github.com/sirupsen/logrus"
 	"github.com/tinyci/ci-agents/clients/data"
+	"github.com/tinyci/ci-agents/config"
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/urfave/cli"
 )
@@ -45,7 +46,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "datasvc, d",
 			Usage: "Location of datasvc",
-			Value: "localhost:6000",
+			Value: config.DefaultServices.Data.String(),
 		},
 		cli.StringFlag{
 			Name:  "cacert, ca",

--- a/cmd/datasvc/main.go
+++ b/cmd/datasvc/main.go
@@ -56,7 +56,7 @@ func serve(ctx *cli.Context) error {
 		return certErr
 	}
 
-	t, transportErr := transport.Listen(cert, "tcp", fmt.Sprintf(":%d", 6000)) // FIXME parameterize
+	t, transportErr := transport.Listen(cert, "tcp", fmt.Sprintf(":%d", config.DefaultServices.Data.Port)) // FIXME parameterize
 	if transportErr != nil {
 		return transportErr
 	}

--- a/cmd/logsvc/main.go
+++ b/cmd/logsvc/main.go
@@ -54,7 +54,7 @@ func serve(ctx *cli.Context) error {
 		return certErr
 	}
 
-	t, transportErr := transport.Listen(cert, "tcp", fmt.Sprintf(":%d", 6005)) // FIXME parameterize
+	t, transportErr := transport.Listen(cert, "tcp", fmt.Sprintf(":%d", config.DefaultServices.Log.Port)) // FIXME parameterize
 	if transportErr != nil {
 		return transportErr
 	}

--- a/cmd/queuesvc/main.go
+++ b/cmd/queuesvc/main.go
@@ -54,7 +54,7 @@ func serve(ctx *cli.Context) error {
 		return certErr
 	}
 
-	t, transportErr := transport.Listen(cert, "tcp", fmt.Sprintf(":%d", 6001)) // FIXME parameterize
+	t, transportErr := transport.Listen(cert, "tcp", fmt.Sprintf(":%d", config.DefaultServices.Queue.Port)) // FIXME parameterize
 	if transportErr != nil {
 		return transportErr
 	}

--- a/cmd/reposvc/github-reposvc/main.go
+++ b/cmd/reposvc/github-reposvc/main.go
@@ -54,7 +54,7 @@ func serve(ctx *cli.Context) error {
 		return certErr
 	}
 
-	t, transportErr := transport.Listen(cert, "tcp", fmt.Sprintf(":%d", 6003)) // FIXME parameterize
+	t, transportErr := transport.Listen(cert, "tcp", fmt.Sprintf(":%d", config.DefaultServices.Repository.Port)) // FIXME parameterize
 	if transportErr != nil {
 		return transportErr
 	}

--- a/cmd/tinyci-adduser/main.go
+++ b/cmd/tinyci-adduser/main.go
@@ -7,6 +7,7 @@ import (
 	transport "github.com/erikh/go-transport"
 	"github.com/tinyci/ci-agents/clients/data"
 	"github.com/tinyci/ci-agents/clients/github"
+	"github.com/tinyci/ci-agents/config"
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/model"
 	"github.com/tinyci/ci-agents/types"
@@ -31,7 +32,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "datasvc, d",
 			Usage: "Location of datasvc",
-			Value: "localhost:6000",
+			Value: config.DefaultServices.Data.String(),
 		},
 		cli.StringFlag{
 			Name:  "cacert, ca",

--- a/config/routes.go
+++ b/config/routes.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AddressMap is a mapping of service -> service address
+type AddressMap struct {
+	Data       ServiceAddress
+	Queue      ServiceAddress
+	UI         ServiceAddress
+	Asset      ServiceAddress
+	Repository ServiceAddress
+	Log        ServiceAddress
+}
+
+// DefaultServices is the standard array of service mappings when unconfigured.
+var DefaultServices = AddressMap{
+	Data:       ServiceAddress{Port: 6000},
+	Queue:      ServiceAddress{Port: 6001},
+	Asset:      ServiceAddress{Port: 6002},
+	Repository: ServiceAddress{Port: 6003},
+	Log:        ServiceAddress{Port: 6005},
+	UI:         ServiceAddress{Port: 6010, HTTP: true},
+}
+
+// ServiceAddress is a well-formed address for service connections
+type ServiceAddress struct {
+	Hostname string
+	Port     uint
+	HTTP     bool
+	TLS      bool
+}
+
+func (sa ServiceAddress) String() string {
+	hostname := sa.Hostname
+	if hostname == "" {
+		hostname = "localhost"
+	}
+
+	str := strings.Join([]string{hostname, fmt.Sprintf("%v", sa.Port)}, ":")
+	if sa.HTTP {
+		if sa.TLS {
+			str = "https://" + str
+		} else {
+			str = "http://" + str
+		}
+	}
+
+	return str
+}

--- a/config/service.go
+++ b/config/service.go
@@ -19,12 +19,12 @@ var DefaultGithubClient github.Client
 
 // TestClientConfig is a default test client configuration
 var TestClientConfig = ClientConfig{
-	Data:       "localhost:6000",
-	Queue:      "localhost:6001",
-	UI:         "http://localhost:6010",
-	Asset:      "localhost:6002",
-	Repository: "localhost:6003",
-	Log:        "localhost:6005",
+	Data:       DefaultServices.Data.String(),
+	Queue:      DefaultServices.Queue.String(),
+	UI:         DefaultServices.UI.String(),
+	Asset:      DefaultServices.Asset.String(),
+	Repository: DefaultServices.Repository.String(),
+	Log:        DefaultServices.Log.String(),
 }
 
 // ServiceConfig is the pre-normalized version of the config struct

--- a/testutil/testclients/datasvc.go
+++ b/testutil/testclients/datasvc.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-github/github"
 	"github.com/tinyci/ci-agents/clients/data"
+	"github.com/tinyci/ci-agents/config"
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/model"
 	"github.com/tinyci/ci-agents/testutil"
@@ -19,7 +20,7 @@ type DataClient struct {
 
 // NewDataClient returns a new datasvc client with window dressings for tests.
 func NewDataClient() (*DataClient, *errors.Error) {
-	ops, err := data.New("localhost:6000", nil, false)
+	ops, err := data.New(config.DefaultServices.Data.String(), nil, false)
 	return &DataClient{client: ops}, err
 }
 

--- a/testutil/testclients/queuesvc.go
+++ b/testutil/testclients/queuesvc.go
@@ -7,6 +7,7 @@ import (
 
 	gh "github.com/google/go-github/github"
 	"github.com/tinyci/ci-agents/clients/queue"
+	"github.com/tinyci/ci-agents/config"
 	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/mocks/github"
 	"github.com/tinyci/ci-agents/types"
@@ -21,7 +22,7 @@ type QueueClient struct {
 
 // NewQueueClient returns a new queuesvc client with window dressings for tests.
 func NewQueueClient(dc *DataClient) (*QueueClient, error) {
-	ops, err := queue.New("localhost:6001", nil, false)
+	ops, err := queue.New(config.DefaultServices.Queue.String(), nil, false)
 	return &QueueClient{client: ops, dataClient: dc}, err
 }
 


### PR DESCRIPTION
This adds a basic static route mapping atop the configuration already
provided; this allows us to easier manipulate defaults and manage port
maps as the service count grows.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
