### PR TITLE
Fix time of creation not getting set in submissions.

### DIFF
--- a/api/datasvc/basic_test.go
+++ b/api/datasvc/basic_test.go
@@ -402,10 +402,15 @@ func (ds *datasvcSuite) TestSubmissions(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(s2.ID, check.Equals, s.ID)
 		c.Assert(s2.TasksCount, check.Equals, int64(1000))
+		c.Assert(s2.CreatedAt.IsZero(), check.Equals, false)
 
 		for x := int64(0); x < 10; x++ {
 			tasks2, err := ds.client.Client().GetTasksForSubmission(s, x, 100)
 			c.Assert(err, check.IsNil)
+
+			for _, task := range tasks2 {
+				c.Assert(task.Submission.CreatedAt.IsZero(), check.Equals, false)
+			}
 
 			sliceTasks := tasks[x*100 : (x+1)*100]
 

--- a/clients/data/submission.go
+++ b/clients/data/submission.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tinyci/ci-agents/model"
 )
 
-// PutSubmission puts a submission into the datasvc
+// PutSubmission puts a submission into the datasvc. Updates the created_at time.
 func (c *Client) PutSubmission(sub *model.Submission) (*model.Submission, *errors.Error) {
 	s, err := c.client.PutSubmission(context.Background(), sub.ToProto())
 	if err != nil {

--- a/model/submission.go
+++ b/model/submission.go
@@ -104,6 +104,13 @@ func NewSubmissionFromProto(gt *gtypes.Submission) (*Submission, *errors.Error) 
 	}
 
 	created := MakeTime(gt.CreatedAt, false)
+
+	if created.IsZero() {
+		// this is a new record and hasn't been updated. Bump the created_at time.
+		t := time.Now()
+		created = &t
+	}
+
 	finished := MakeTime(gt.FinishedAt, true)
 	started := MakeTime(gt.StartedAt, true)
 


### PR DESCRIPTION
closes tinyci/ci-ui#62

This was never getting updated as a part of the initial record write.