### PR TITLE
Upgrade ci-gen image

### DIFF
--- a/ci-gen/Makefile
+++ b/ci-gen/Makefile
@@ -18,6 +18,9 @@ get-box:
 build-gen-image: get-box
 	box -t $(DOCKER_IMAGE) box.rb
 
+tag-gen-image: get-box
+	PACKAGE_FOR_CI=1 TESTING=1 box -n -t tinyci/ci-gen:$(shell date '+%m.%d.%Y') box.rb
+
 gen: gen-javascript build-gen-image
 	$(DOCKER_RUN) -u $$(id -u):$$(id -g) $(DOCKER_CONTAINER_DIR) $(DOCKER_IMAGE) bash ci-gen/gen.sh
 

--- a/ci-gen/box.rb
+++ b/ci-gen/box.rb
@@ -1,4 +1,4 @@
-GO_VERSION = "1.12.7"
+GO_VERSION = "1.13"
 SWAGGER_VERSION = "v0.18.0"
 PROTOC_VERSION = "3.7.1"
 
@@ -15,7 +15,15 @@ EXTRA_PACKAGES = %w[
   unzip
 ]
 
-from "ubuntu:18.04"
+from "ubuntu:19.04"
+
+after do
+  if getenv("PACKAGE_FOR_CI") != ""
+    run "apt-get clean"
+    run "rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /root/.cache"
+    flatten
+  end
+end
 
 run %Q[perl -i.bak -pe 's!//(security|archive).ubuntu.com!//#{getenv("APT_MIRROR").length > 0 ? getenv("APT_MIRROR") : "mirror.pnl.gov"}!g' /etc/apt/sources.list]
 
@@ -25,7 +33,6 @@ run "ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime"
 
 env GOPATH: "/go",
     PATH: %w[
-      /usr/lib/postgresql/9.6/bin
       /go/bin
       /usr/local/go/bin
       /usr/local/sbin
@@ -49,5 +56,5 @@ run "go get -u github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 protoc_fn = "protoc-#{PROTOC_VERSION}-linux-x86_64.zip"
 
 run "wget https://github.com/protocolbuffers/protobuf/releases/download/v#{PROTOC_VERSION}/#{protoc_fn}"
-run "unzip '#{protoc_fn}' -d /usr"
+run "unzip '#{protoc_fn}' -d /usr && rm -f '#{protoc_fn}'"
 run "curl -sSL 'https://github.com/go-swagger/go-swagger/releases/download/#{SWAGGER_VERSION}/swagger_linux_amd64' >/go/bin/swagger && chmod +x /go/bin/swagger"

--- a/ci-gen/task.yml
+++ b/ci-gen/task.yml
@@ -1,6 +1,6 @@
 mountpoint: "/go/src/github.com/tinyci/ci-agents"
 workdir: "/go/src/github.com/tinyci/ci-agents"
-default_image: tinyci/ci-gen:08.01.2019
+default_image: tinyci/ci-gen:09.18.2019
 runs:
   gen-clean:
     command: [ "bash", "-c", "bash ci-gen/gen.sh && git diff --stat --exit-code" ]


### PR DESCRIPTION
This makes it in sync with our ci-agents image:

* golang 1.13
* ubuntu 19.04 disco

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
