### PR TITLE
Repopulate ticket id in submission conversion

### DIFF
--- a/model/submission.go
+++ b/model/submission.go
@@ -131,6 +131,7 @@ func NewSubmissionFromProto(gt *gtypes.Submission) (*Submission, *errors.Error) 
 		StartedAt:  started,
 		Status:     status,
 		Canceled:   gt.Canceled,
+		TicketID:   gt.TicketID,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes ticket recording in database.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
