### PR TITLE
Make github client use contexts

### DIFF
--- a/api/queuesvc/basic_test.go
+++ b/api/queuesvc/basic_test.go
@@ -47,22 +47,22 @@ func (qs *queuesvcSuite) TestBadYAML(c *check.C) {
 	taskBytes, e := ioutil.ReadFile("../testdata/bad_task.yml")
 	c.Assert(e, check.IsNil)
 
-	qs.getMock().GetRepository("erikh/foobar2").Return(&gh.Repository{FullName: gh.String("erikh/foobar2")}, nil)
-	qs.getMock().GetRepository("erikh/foobar").Return(&gh.Repository{FullName: gh.String("erikh/foobar")}, nil)
-	qs.getMock().GetRefs(sub.Fork, sub.HeadSHA).Return([]string{"heads/master"}, nil)
-	qs.getMock().GetRefs(sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil)
-	qs.getMock().GetFile(sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
-	qs.getMock().GetDiffFiles(sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml"}, nil)
-	qs.getMock().GetFileList(sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
-	qs.getMock().GetRepository(sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
-	qs.getMock().CommentError(sub.Parent, sub.TicketID, gomock.Any()).Return(nil)
+	qs.getMock().GetRepository(gomock.Any(), "erikh/foobar2").Return(&gh.Repository{FullName: gh.String("erikh/foobar2")}, nil)
+	qs.getMock().GetRepository(gomock.Any(), "erikh/foobar").Return(&gh.Repository{FullName: gh.String("erikh/foobar")}, nil)
+	qs.getMock().GetRefs(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"heads/master"}, nil)
+	qs.getMock().GetRefs(gomock.Any(), sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
+	qs.getMock().GetDiffFiles(gomock.Any(), sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml"}, nil)
+	qs.getMock().GetFileList(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
+	qs.getMock().GetRepository(gomock.Any(), sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
+	qs.getMock().CommentError(gomock.Any(), sub.Parent, sub.TicketID, gomock.Any()).Return(nil)
 
-	qs.getMock().GetFile(sub.Fork, sub.HeadSHA, "task.yml").Return(taskBytes, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "task.yml").Return(taskBytes, nil)
 
-	qs.getMock().ClearStates(sub.Parent, sub.HeadSHA).Return(nil)
+	qs.getMock().ClearStates(gomock.Any(), sub.Parent, sub.HeadSHA).Return(nil)
 	c.Assert(qs.datasvcClient.Client().EnableRepository("erikh", sub.Parent), check.IsNil)
 
-	qs.getMock().FinishedStatus("erikh", "foobar", "*global*", "be3d26c478991039e951097f2c99f56b55396940", "url", false, gomock.Any()).Return(nil)
+	qs.getMock().FinishedStatus(gomock.Any(), "erikh", "foobar", "*global*", "be3d26c478991039e951097f2c99f56b55396940", "url", false, gomock.Any()).Return(nil)
 
 	c.Assert(qs.queuesvcClient.Client().Submit(context.Background(), sub), check.NotNil)
 	runs, err := qs.datasvcClient.Client().ListRuns("", "", 0, 100)
@@ -129,10 +129,10 @@ func (qs *queuesvcSuite) TestManualSubmission(c *check.C) {
 	}
 
 	c.Assert(qs.queuesvcClient.SetUpSubmissionRepo(sub.Parent, ""), check.IsNil)
-	qs.getMock().GetSHA(sub.Fork, "heads/master").Return("be3d26c478991039e951097f2c99f56b55396940", nil)
-	qs.getMock().GetSHA(sub.Parent, "heads/master").Return("be3d26c478991039e951097f2c99f56b55396941", nil)
+	qs.getMock().GetSHA(gomock.Any(), sub.Fork, "heads/master").Return("be3d26c478991039e951097f2c99f56b55396940", nil)
+	qs.getMock().GetSHA(gomock.Any(), sub.Parent, "heads/master").Return("be3d26c478991039e951097f2c99f56b55396941", nil)
 	c.Assert(qs.queuesvcClient.SetMockSubmissionSuccess(qs.getMock(), sub, ""), check.IsNil)
-	qs.getMock().ClearStates(sub.Parent, sub.HeadSHA).Return(nil)
+	qs.getMock().ClearStates(gomock.Any(), sub.Parent, sub.HeadSHA).Return(nil)
 	c.Assert(qs.queuesvcClient.Client().Submit(context.Background(), msub), check.IsNil)
 
 	qis, err := qs.datasvcClient.Client().ListRuns(sub.Fork, "be3d26c478991039e951097f2c99f56b55396940", 0, 100)
@@ -142,6 +142,7 @@ func (qs *queuesvcSuite) TestManualSubmission(c *check.C) {
 		// original sha from first run
 		qs.getMock().
 			ErrorStatus(
+				gomock.Any(),
 				"erikh",
 				"foobar",
 				qis[i].Name,
@@ -166,10 +167,10 @@ func (qs *queuesvcSuite) TestManualSubmission(c *check.C) {
 		TicketID: 10,
 	}
 
-	qs.getMock().GetSHA(sub.Fork, "heads/foobar").Return("be3d26c478991039e951097f2c99f56b55396942", nil) // also here
-	qs.getMock().GetSHA(sub.Parent, "heads/master").Return("be3d26c478991039e951097f2c99f56b55396941", nil)
+	qs.getMock().GetSHA(gomock.Any(), sub.Fork, "heads/foobar").Return("be3d26c478991039e951097f2c99f56b55396942", nil) // also here
+	qs.getMock().GetSHA(gomock.Any(), sub.Parent, "heads/master").Return("be3d26c478991039e951097f2c99f56b55396941", nil)
 	c.Assert(qs.queuesvcClient.SetMockSubmissionSuccess(qs.getMock(), sub, ""), check.IsNil)
-	qs.getMock().ClearStates(sub.Parent, sub.HeadSHA).Return(nil)
+	qs.getMock().ClearStates(gomock.Any(), sub.Parent, sub.HeadSHA).Return(nil)
 	c.Assert(qs.queuesvcClient.Client().Submit(context.Background(), msub), check.IsNil)
 
 	qis, err = qs.datasvcClient.Client().ListRuns(sub.Fork, "be3d26c478991039e951097f2c99f56b55396942", 0, 100)
@@ -178,13 +179,14 @@ func (qs *queuesvcSuite) TestManualSubmission(c *check.C) {
 
 	// cancellation tests
 
-	qs.getMock().GetSHA(sub.Fork, "heads/foobar").Return("be3d26c478991039e951097f2c99f56b55396942", nil) // also here
-	qs.getMock().GetSHA(sub.Parent, "heads/master").Return("be3d26c478991039e951097f2c99f56b55396941", nil)
+	qs.getMock().GetSHA(gomock.Any(), sub.Fork, "heads/foobar").Return("be3d26c478991039e951097f2c99f56b55396942", nil) // also here
+	qs.getMock().GetSHA(gomock.Any(), sub.Parent, "heads/master").Return("be3d26c478991039e951097f2c99f56b55396941", nil)
 
 	for i := len(qis) - 1; i >= 0; i-- {
 		// original sha from first run
 		qs.getMock().
 			ErrorStatus(
+				gomock.Any(),
 				"erikh",
 				"foobar",
 				qis[i].Name,
@@ -195,7 +197,7 @@ func (qs *queuesvcSuite) TestManualSubmission(c *check.C) {
 	}
 
 	c.Assert(qs.queuesvcClient.SetMockSubmissionSuccess(qs.getMock(), sub, ""), check.IsNil)
-	qs.getMock().ClearStates(sub.Parent, sub.HeadSHA).Return(nil)
+	qs.getMock().ClearStates(gomock.Any(), sub.Parent, sub.HeadSHA).Return(nil)
 	c.Assert(qs.queuesvcClient.Client().Submit(context.Background(), msub), check.IsNil)
 
 	qis, err = qs.datasvcClient.Client().ListRuns(sub.Fork, "be3d26c478991039e951097f2c99f56b55396942", 0, 100)
@@ -223,7 +225,7 @@ func (qs *queuesvcSuite) TestSubmission2(c *check.C) {
 
 	c.Assert(qs.queuesvcClient.SetUpSubmissionRepo(sub.Parent, ""), check.IsNil)
 	c.Assert(qs.queuesvcClient.SetMockSubmissionSuccess(qs.getMock(), sub, ""), check.IsNil)
-	qs.getMock().ClearStates(sub.Parent, sub.HeadSHA).Return(nil)
+	qs.getMock().ClearStates(gomock.Any(), sub.Parent, sub.HeadSHA).Return(nil)
 
 	c.Assert(qs.queuesvcClient.Client().Submit(context.Background(), sub), check.IsNil)
 	runs, err := qs.datasvcClient.Client().ListRuns("", "", 0, 100)
@@ -240,7 +242,7 @@ func (qs *queuesvcSuite) TestSubmission2(c *check.C) {
 
 	c.Assert(qs.queuesvcClient.SetUpSubmissionRepo(sub.Parent, ""), check.IsNil)
 	c.Assert(qs.queuesvcClient.SetMockSubmissionSuccess(qs.getMock(), sub, ""), check.IsNil)
-	qs.getMock().ClearStates(sub.Parent, sub.HeadSHA).Return(nil)
+	qs.getMock().ClearStates(gomock.Any(), sub.Parent, sub.HeadSHA).Return(nil)
 
 	c.Assert(qs.queuesvcClient.Client().Submit(context.Background(), sub), check.IsNil)
 	runs, err = qs.datasvcClient.Client().ListRuns("", "", 0, 100)
@@ -271,25 +273,25 @@ func (qs *queuesvcSuite) TestSubmission(c *check.C) {
 	taskBytes, e := ioutil.ReadFile("../testdata/standard_task.yml")
 	c.Assert(e, check.IsNil)
 
-	qs.getMock().GetRepository("erikh/foobar2").Return(&gh.Repository{FullName: gh.String("erikh/foobar2")}, nil)
-	qs.getMock().GetRepository("erikh/foobar").Return(&gh.Repository{FullName: gh.String("erikh/foobar")}, nil)
-	qs.getMock().GetRefs(sub.Fork, sub.HeadSHA).Return([]string{"heads/master"}, nil)
-	qs.getMock().GetRefs(sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil)
-	qs.getMock().GetFile(sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
-	qs.getMock().GetDiffFiles(sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar"}, nil)
-	qs.getMock().GetFileList(sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
-	qs.getMock().GetRepository(sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
+	qs.getMock().GetRepository(gomock.Any(), "erikh/foobar2").Return(&gh.Repository{FullName: gh.String("erikh/foobar2")}, nil)
+	qs.getMock().GetRepository(gomock.Any(), "erikh/foobar").Return(&gh.Repository{FullName: gh.String("erikh/foobar")}, nil)
+	qs.getMock().GetRefs(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"heads/master"}, nil)
+	qs.getMock().GetRefs(gomock.Any(), sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
+	qs.getMock().GetDiffFiles(gomock.Any(), sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar"}, nil)
+	qs.getMock().GetFileList(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
+	qs.getMock().GetRepository(gomock.Any(), sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
 
-	qs.getMock().GetFile(sub.Fork, sub.HeadSHA, "foo/task.yml").Return(taskBytes, nil)
-	qs.getMock().GetFile(sub.Fork, sub.HeadSHA, "task.yml").Return(taskBytes, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "foo/task.yml").Return(taskBytes, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "task.yml").Return(taskBytes, nil)
 
 	for _, name := range []string{"*root*", "foo"} {
 		for x := 1; x <= 5; x++ {
-			qs.getMock().PendingStatus("erikh", "foobar", fmt.Sprintf("%s:%d", name, x), sub.HeadSHA, "url")
+			qs.getMock().PendingStatus(gomock.Any(), "erikh", "foobar", fmt.Sprintf("%s:%d", name, x), sub.HeadSHA, "url")
 		}
 	}
 
-	qs.getMock().ClearStates(sub.Parent, sub.HeadSHA).Return(nil)
+	qs.getMock().ClearStates(gomock.Any(), sub.Parent, sub.HeadSHA).Return(nil)
 	c.Assert(qs.datasvcClient.Client().EnableRepository("erikh", sub.Parent), check.IsNil)
 
 	c.Assert(qs.queuesvcClient.Client().Submit(context.Background(), sub), check.IsNil)
@@ -344,25 +346,25 @@ func (qs *queuesvcSuite) TestDependencies(c *check.C) {
 	standardTaskBytes, e := ioutil.ReadFile("../testdata/standard_task.yml")
 	c.Assert(e, check.IsNil)
 
-	qs.getMock().GetRepository("erikh/foobar2").Return(&gh.Repository{FullName: gh.String("erikh/foobar2")}, nil)
-	qs.getMock().GetRepository("erikh/foobar").Return(&gh.Repository{FullName: gh.String("erikh/foobar")}, nil)
-	qs.getMock().GetRefs(sub.Fork, sub.HeadSHA).Return([]string{"heads/master"}, nil)
-	qs.getMock().GetRefs(sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil)
-	qs.getMock().GetFile(sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
-	qs.getMock().GetDiffFiles(sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml"}, nil)
-	qs.getMock().GetFileList(sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
-	qs.getMock().GetRepository(sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
+	qs.getMock().GetRepository(gomock.Any(), "erikh/foobar2").Return(&gh.Repository{FullName: gh.String("erikh/foobar2")}, nil)
+	qs.getMock().GetRepository(gomock.Any(), "erikh/foobar").Return(&gh.Repository{FullName: gh.String("erikh/foobar")}, nil)
+	qs.getMock().GetRefs(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"heads/master"}, nil)
+	qs.getMock().GetRefs(gomock.Any(), sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
+	qs.getMock().GetDiffFiles(gomock.Any(), sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml"}, nil)
+	qs.getMock().GetFileList(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
+	qs.getMock().GetRepository(gomock.Any(), sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
 
-	qs.getMock().GetFile(sub.Fork, sub.HeadSHA, "task.yml").Return(taskBytes, nil)
-	qs.getMock().GetFile(sub.Fork, sub.HeadSHA, "bar/task.yml").Return(depTaskBytes, nil)
-	qs.getMock().GetFile(sub.Fork, sub.HeadSHA, "foo/task.yml").Return(standardTaskBytes, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "task.yml").Return(taskBytes, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "bar/task.yml").Return(depTaskBytes, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "foo/task.yml").Return(standardTaskBytes, nil)
 
-	qs.getMock().PendingStatus("erikh", "foobar", "*root*:1", sub.HeadSHA, "url")
+	qs.getMock().PendingStatus(gomock.Any(), "erikh", "foobar", "*root*:1", sub.HeadSHA, "url")
 	for x := 1; x <= 5; x++ {
-		qs.getMock().PendingStatus("erikh", "foobar", fmt.Sprintf("%s:%d", "foo", x), sub.HeadSHA, "url")
+		qs.getMock().PendingStatus(gomock.Any(), "erikh", "foobar", fmt.Sprintf("%s:%d", "foo", x), sub.HeadSHA, "url")
 	}
 
-	qs.getMock().ClearStates(sub.Parent, sub.HeadSHA).Return(nil)
+	qs.getMock().ClearStates(gomock.Any(), sub.Parent, sub.HeadSHA).Return(nil)
 	c.Assert(qs.datasvcClient.Client().EnableRepository("erikh", sub.Parent), check.IsNil)
 
 	c.Assert(qs.queuesvcClient.Client().Submit(context.Background(), sub), check.IsNil)
@@ -389,7 +391,7 @@ func (qs *queuesvcSuite) TestBasic(c *check.C) {
 		TicketID: 10,
 	}
 
-	_, _, _, err = ManageRepositories(qs.queueHandler, sub)
+	_, _, _, err = ManageRepositories(context.Background(), qs.queueHandler, sub)
 	c.Assert(err, check.NotNil)
 
 	qs.mkGithubClient(github.NewMockClient(gomock.NewController(c)))
@@ -398,11 +400,11 @@ func (qs *queuesvcSuite) TestBasic(c *check.C) {
 	c.Assert(qs.datasvcClient.Client().EnableRepository("erikh", "erikh/foobar"), check.IsNil)
 
 	gomock.InOrder(
-		qs.getMock().GetRepository("erikh/foobar2").Return(&gh.Repository{FullName: gh.String("erikh/foobar2")}, nil),
-		qs.getMock().GetRepository("erikh/foobar").Return(&gh.Repository{FullName: gh.String("erikh/foobar")}, nil),
+		qs.getMock().GetRepository(gomock.Any(), "erikh/foobar2").Return(&gh.Repository{FullName: gh.String("erikh/foobar2")}, nil),
+		qs.getMock().GetRepository(gomock.Any(), "erikh/foobar").Return(&gh.Repository{FullName: gh.String("erikh/foobar")}, nil),
 	)
 
-	parent, fork, _, err := ManageRepositories(qs.queueHandler, sub)
+	parent, fork, _, err := ManageRepositories(context.Background(), qs.queueHandler, sub)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(parent.ID, check.Not(check.Equals), int64(0))
@@ -412,35 +414,35 @@ func (qs *queuesvcSuite) TestBasic(c *check.C) {
 	c.Assert(fork.AutoCreated, check.Equals, true)
 
 	gomock.InOrder(
-		qs.getMock().GetRefs(sub.Fork, sub.HeadSHA).Return([]string{"heads/master"}, nil),
+		qs.getMock().GetRefs(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"heads/master"}, nil),
 	)
 
-	forkRef, err := ManageRefs(qs.queueHandler, config.DefaultGithubClient, fork, sub.HeadSHA)
+	forkRef, err := ManageRefs(context.Background(), qs.queueHandler, config.DefaultGithubClient, fork, sub.HeadSHA)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(forkRef.SHA, check.Equals, sub.HeadSHA)
 	c.Assert(forkRef.RefName, check.Equals, "heads/master")
 
 	gomock.InOrder(
-		qs.getMock().GetRefs(sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil),
+		qs.getMock().GetRefs(gomock.Any(), sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil),
 	)
 
-	parentRef, err := ManageRefs(qs.queueHandler, config.DefaultGithubClient, parent, sub.BaseSHA)
+	parentRef, err := ManageRefs(context.Background(), qs.queueHandler, config.DefaultGithubClient, parent, sub.BaseSHA)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(parentRef.SHA, check.Equals, sub.BaseSHA)
 	c.Assert(parentRef.RefName, check.Equals, "heads/master")
 
 	gomock.InOrder(
-		qs.getMock().GetDiffFiles(sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "untested/bar", "untested/task.yml"}, nil),
-		qs.getMock().GetFileList(sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil),
+		qs.getMock().GetDiffFiles(gomock.Any(), sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "untested/bar", "untested/task.yml"}, nil),
+		qs.getMock().GetFileList(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil),
 	)
 
 	rc := &types.RepoConfig{
 		IgnoreDirs: []string{"untested"},
 	}
 
-	processMap, err := PickTasks(config.DefaultGithubClient, sub, forkRef, parent, rc)
+	processMap, err := PickTasks(context.Background(), config.DefaultGithubClient, sub, forkRef, parent, rc)
 	c.Assert(err, check.IsNil)
 
 	for _, key := range []string{".", "foo"} {
@@ -457,10 +459,10 @@ func (qs *queuesvcSuite) TestBasic(c *check.C) {
 	repoConfigBytes, e := ioutil.ReadFile("../testdata/standard_repoconfig.yml")
 	c.Assert(e, check.IsNil)
 
-	qs.getMock().GetRepository(sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
-	qs.getMock().GetFile(sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
+	qs.getMock().GetRepository(gomock.Any(), sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
 
-	repoConfig, err := GetRepoConfig(config.DefaultGithubClient, sub)
+	repoConfig, err := GetRepoConfig(context.Background(), config.DefaultGithubClient, sub)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(repoConfig.Queue, check.Equals, "repoconfig")
@@ -469,8 +471,8 @@ func (qs *queuesvcSuite) TestBasic(c *check.C) {
 	taskBytes, e := ioutil.ReadFile("../testdata/standard_task.yml")
 	c.Assert(e, check.IsNil)
 
-	qs.getMock().GetFile(sub.Fork, sub.HeadSHA, "task.yml").Return(taskBytes, nil)
-	qs.getMock().GetFile(sub.Fork, sub.HeadSHA, "foo/task.yml").Return(taskBytes, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "task.yml").Return(taskBytes, nil)
+	qs.getMock().GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "foo/task.yml").Return(taskBytes, nil)
 
 	parts := strings.SplitN(parent.Name, "/", 2)
 	c.Assert(len(parts), check.Equals, 2)
@@ -478,12 +480,12 @@ func (qs *queuesvcSuite) TestBasic(c *check.C) {
 	for _, name := range []string{"*root*", "foo"} {
 		for x := 1; x <= 5; x++ {
 			gomock.InOrder(
-				qs.getMock().PendingStatus(parts[0], parts[1], fmt.Sprintf("%s:%d", name, x), sub.HeadSHA, "url"),
+				qs.getMock().PendingStatus(gomock.Any(), parts[0], parts[1], fmt.Sprintf("%s:%d", name, x), sub.HeadSHA, "url"),
 			)
 		}
 	}
 
-	qs.getMock().ClearStates(sub.Parent, sub.HeadSHA).Return(nil)
+	qs.getMock().ClearStates(gomock.Any(), sub.Parent, sub.HeadSHA).Return(nil)
 	qis, err := GenerateQueueItems(
 		context.Background(),
 		qs.queueHandler,

--- a/api/queuesvc/routes.go
+++ b/api/queuesvc/routes.go
@@ -87,7 +87,7 @@ func (qs *QueueServer) NextQueueItem(ctx context.Context, qr *gtypes.QueueReques
 	}
 
 	go func() {
-		if err := github.StartedStatus(parts[0], parts[1], qi.Run.Name, qi.Run.Task.Ref.SHA, fmt.Sprintf("%s/log/%d", qs.H.URL, qi.Run.ID)); err != nil {
+		if err := github.StartedStatus(ctx, parts[0], parts[1], qi.Run.Name, qi.Run.Task.Ref.SHA, fmt.Sprintf("%s/log/%d", qs.H.URL, qi.Run.ID)); err != nil {
 			fmt.Println(err)
 		}
 	}()

--- a/api/uisvc/restapi/basic_test.go
+++ b/api/uisvc/restapi/basic_test.go
@@ -105,11 +105,11 @@ func (us *uisvcSuite) TestSubmit(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer close(doneChan)
 
-	client.EXPECT().GetRepository("erikh/not-real").Return(nil, errors.New("not found"))
+	client.EXPECT().GetRepository(gomock.Any(), "erikh/not-real").Return(nil, errors.New("not found"))
 
 	c.Assert(tc.Submit("erikh/not-real", "master", true), check.ErrorMatches, ".* not found")
 
-	client.EXPECT().MyRepositories().Return([]*gh.Repository{{FullName: gh.String("erikh/parent")}}, nil)
+	client.EXPECT().MyRepositories(gomock.Any()).Return([]*gh.Repository{{FullName: gh.String("erikh/parent")}}, nil)
 
 	repos, err := tc.LoadRepositories("")
 	c.Assert(err, check.IsNil)
@@ -117,7 +117,7 @@ func (us *uisvcSuite) TestSubmit(c *check.C) {
 
 	c.Assert(us.datasvcClient.Client().EnableRepository("erikh", "erikh/parent"), check.IsNil)
 
-	client.EXPECT().GetRepository("erikh/not-real").Return(nil, errors.New("not found"))
+	client.EXPECT().GetRepository(gomock.Any(), "erikh/not-real").Return(nil, errors.New("not found"))
 	c.Assert(tc.Submit("erikh/not-real", "master", true), check.ErrorMatches, ".* not found")
 
 	sub := &types.Submission{
@@ -131,20 +131,20 @@ func (us *uisvcSuite) TestSubmit(c *check.C) {
 
 	c.Assert(us.queuesvcClient.SetMockSubmissionSuccess(client.EXPECT(), sub, "../"), check.IsNil)
 
-	client.EXPECT().GetSHA("erikh/parent", "heads/master").Return("", errors.New("not found"))
-	client.EXPECT().GetSHA("erikh/test", "heads/master").Return("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", nil)
+	client.EXPECT().GetSHA(gomock.Any(), "erikh/parent", "heads/master").Return("", errors.New("not found"))
+	client.EXPECT().GetSHA(gomock.Any(), "erikh/test", "heads/master").Return("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", nil)
 
 	c.Assert(tc.Submit("erikh/test", "master", true), check.ErrorMatches, ".*not found")
 
-	client.EXPECT().GetSHA("erikh/parent", "heads/master").Return("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", nil)
-	client.EXPECT().GetSHA("erikh/test", "heads/master").Return("", errors.New("not found"))
+	client.EXPECT().GetSHA(gomock.Any(), "erikh/parent", "heads/master").Return("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", nil)
+	client.EXPECT().GetSHA(gomock.Any(), "erikh/test", "heads/master").Return("", errors.New("not found"))
 
 	c.Assert(tc.Submit("erikh/test", "master", true), check.ErrorMatches, ".*not found")
 
 	c.Assert(us.queuesvcClient.SetMockSubmissionSuccess(client.EXPECT(), sub, "../"), check.IsNil)
-	client.EXPECT().GetSHA("erikh/parent", "heads/master").Return("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", nil)
-	client.EXPECT().GetSHA("erikh/test", "heads/master").Return("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", nil)
-	client.EXPECT().ClearStates("erikh/parent", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").Return(nil)
+	client.EXPECT().GetSHA(gomock.Any(), "erikh/parent", "heads/master").Return("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", nil)
+	client.EXPECT().GetSHA(gomock.Any(), "erikh/test", "heads/master").Return("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", nil)
+	client.EXPECT().ClearStates(gomock.Any(), "erikh/parent", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").Return(nil)
 
 	c.Assert(utc.Submit("erikh/test", "master", true), check.NotNil)
 	c.Assert(tc.Submit("erikh/test", "master", true), check.IsNil)
@@ -189,6 +189,7 @@ func (us *uisvcSuite) TestSubmit(c *check.C) {
 
 	for i := 0; i < len(runs); i++ {
 		client.EXPECT().ErrorStatus(
+			gomock.Any(),
 			"erikh",
 			"parent",
 			gomock.Any(),
@@ -212,7 +213,7 @@ func (us *uisvcSuite) TestAddDeleteCI(c *check.C) {
 
 	c.Assert(tc.AddToCI("f7u12"), check.NotNil)
 
-	client.EXPECT().MyRepositories().Return([]*gh.Repository{{FullName: gh.String("erikh/test")}}, nil)
+	client.EXPECT().MyRepositories(gomock.Any()).Return([]*gh.Repository{{FullName: gh.String("erikh/test")}}, nil)
 
 	repos, err := tc.LoadRepositories("")
 	c.Assert(err, check.IsNil)
@@ -224,22 +225,22 @@ func (us *uisvcSuite) TestAddDeleteCI(c *check.C) {
 
 	c.Assert(tc.AddToCI("erikh/not-real"), check.NotNil) // not saved
 
-	client.EXPECT().TeardownHook("erikh", "test", h.HookURL).Return(errors.New("wat's up"))
+	client.EXPECT().TeardownHook(gomock.Any(), "erikh", "test", h.HookURL).Return(errors.New("wat's up"))
 
 	c.Assert(tc.AddToCI("erikh/test"), check.ErrorMatches, "wat's up")
 
-	client.EXPECT().TeardownHook("erikh", "test", h.HookURL).Return(nil)
-	client.EXPECT().SetupHook("erikh", "test", h.HookURL, gomock.Any()).Return(errors.New("yep"))
+	client.EXPECT().TeardownHook(gomock.Any(), "erikh", "test", h.HookURL).Return(nil)
+	client.EXPECT().SetupHook(gomock.Any(), "erikh", "test", h.HookURL, gomock.Any()).Return(errors.New("yep"))
 
 	c.Assert(tc.AddToCI("erikh/test"), check.ErrorMatches, "yep")
 
-	client.EXPECT().TeardownHook("erikh", "test", h.HookURL).Return(nil)
-	client.EXPECT().SetupHook("erikh", "test", h.HookURL, gomock.Any()).Return(nil)
+	client.EXPECT().TeardownHook(gomock.Any(), "erikh", "test", h.HookURL).Return(nil)
+	client.EXPECT().SetupHook(gomock.Any(), "erikh", "test", h.HookURL, gomock.Any()).Return(nil)
 
 	c.Assert(utc.AddToCI("erikh/test"), check.ErrorMatches, ".*capability.*")
 	c.Assert(tc.AddToCI("erikh/test"), check.IsNil)
 
-	client.EXPECT().MyRepositories().Return([]*gh.Repository{{FullName: gh.String("erikh/test")}}, nil)
+	client.EXPECT().MyRepositories(gomock.Any()).Return([]*gh.Repository{{FullName: gh.String("erikh/test")}}, nil)
 
 	visible, err := tc.Visible("erikh/test")
 	c.Assert(err, check.IsNil)
@@ -251,10 +252,10 @@ func (us *uisvcSuite) TestAddDeleteCI(c *check.C) {
 
 	c.Assert(tc.DeleteFromCI("erikh/not-real"), check.NotNil)
 
-	client.EXPECT().TeardownHook("erikh", "test", h.HookURL).Return(errors.New("wat's up"))
+	client.EXPECT().TeardownHook(gomock.Any(), "erikh", "test", h.HookURL).Return(errors.New("wat's up"))
 	c.Assert(tc.DeleteFromCI("erikh/test"), check.NotNil)
 
-	client.EXPECT().TeardownHook("erikh", "test", h.HookURL).Return(nil)
+	client.EXPECT().TeardownHook(gomock.Any(), "erikh", "test", h.HookURL).Return(nil)
 	c.Assert(utc.DeleteFromCI("erikh/test"), check.NotNil)
 	c.Assert(tc.DeleteFromCI("erikh/test"), check.IsNil)
 	c.Assert(tc.DeleteFromCI("erikh/test"), check.ErrorMatches, "repo is not enabled")
@@ -269,7 +270,7 @@ func (us *uisvcSuite) TestSubscriptions(c *check.C) {
 	c.Assert(tc.Subscribe("erikh/test"), check.NotNil)
 	c.Assert(tc.Unsubscribe("erikh/test"), check.NotNil)
 
-	client.EXPECT().MyRepositories().Return([]*gh.Repository{{FullName: gh.String("erikh/test")}}, nil)
+	client.EXPECT().MyRepositories(gomock.Any()).Return([]*gh.Repository{{FullName: gh.String("erikh/test")}}, nil)
 
 	repos, err := tc.LoadRepositories("")
 	c.Assert(err, check.IsNil)

--- a/api/uisvc/restapi/repository.go
+++ b/api/uisvc/restapi/repository.go
@@ -44,7 +44,7 @@ func ScanRepositories(h *handlers.H, ctx *gin.Context) (interface{}, int, *error
 		return nil, 500, err
 	}
 
-	githubRepos, err := github.MyRepositories()
+	githubRepos, err := github.MyRepositories(ctx)
 	if err != nil {
 		return nil, 500, err
 	}
@@ -103,7 +103,7 @@ func DeleteRepositoryFromCI(h *handlers.H, ctx *gin.Context) (interface{}, int, 
 		return nil, 500, errors.New("repo is not enabled")
 	}
 
-	if err := github.TeardownHook(ctx.GetString("owner"), ctx.GetString("repo"), h.HookURL); err != nil {
+	if err := github.TeardownHook(ctx, ctx.GetString("owner"), ctx.GetString("repo"), h.HookURL); err != nil {
 		return nil, 500, err
 	}
 
@@ -127,7 +127,7 @@ func AddRepositoryToCI(h *handlers.H, ctx *gin.Context) (interface{}, int, *erro
 		return nil, 500, err
 	}
 
-	if err := github.TeardownHook(ctx.GetString("owner"), ctx.GetString("repo"), h.HookURL); err != nil {
+	if err := github.TeardownHook(ctx, ctx.GetString("owner"), ctx.GetString("repo"), h.HookURL); err != nil {
 		return nil, 500, err
 	}
 
@@ -141,7 +141,7 @@ func AddRepositoryToCI(h *handlers.H, ctx *gin.Context) (interface{}, int, *erro
 		return nil, 500, err
 	}
 
-	if err := github.SetupHook(ctx.GetString("owner"), ctx.GetString("repo"), h.HookURL, postRepo.HookSecret); err != nil {
+	if err := github.SetupHook(ctx, ctx.GetString("owner"), ctx.GetString("repo"), h.HookURL, postRepo.HookSecret); err != nil {
 		if err := h.Clients.Data.DisableRepository(user.Username, repoName); err != nil {
 			return nil, 500, err
 		}

--- a/cmd/tinyci-adduser/main.go
+++ b/cmd/tinyci-adduser/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -106,7 +107,7 @@ func run(ctx *cli.Context) error {
 func inspect(token string) (*types.OAuthToken, *errors.Error) {
 	c := github.NewClientFromAccessToken(token)
 
-	login, err := c.MyLogin()
+	login, err := c.MyLogin(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -90,7 +90,7 @@ func (h *H) GetUser(ctx *gin.Context) (*model.User, *errors.Error) {
 			}
 		} else {
 			var err *errors.Error
-			name, err = client.MyLogin()
+			name, err = client.MyLogin(ctx)
 			if err != nil {
 				return nil, errors.New(err)
 			}

--- a/mocks/github/mock.go
+++ b/mocks/github/mock.go
@@ -5,6 +5,7 @@
 package github
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	github "github.com/google/go-github/github"
 	errors "github.com/tinyci/ci-agents/errors"
@@ -35,233 +36,233 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // ClearStates mocks base method
-func (m *MockClient) ClearStates(arg0, arg1 string) *errors.Error {
+func (m *MockClient) ClearStates(arg0 context.Context, arg1, arg2 string) *errors.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClearStates", arg0, arg1)
+	ret := m.ctrl.Call(m, "ClearStates", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*errors.Error)
 	return ret0
 }
 
 // ClearStates indicates an expected call of ClearStates
-func (mr *MockClientMockRecorder) ClearStates(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ClearStates(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearStates", reflect.TypeOf((*MockClient)(nil).ClearStates), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearStates", reflect.TypeOf((*MockClient)(nil).ClearStates), arg0, arg1, arg2)
 }
 
 // CommentError mocks base method
-func (m *MockClient) CommentError(arg0 string, arg1 int64, arg2 *errors.Error) *errors.Error {
+func (m *MockClient) CommentError(arg0 context.Context, arg1 string, arg2 int64, arg3 *errors.Error) *errors.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CommentError", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CommentError", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*errors.Error)
 	return ret0
 }
 
 // CommentError indicates an expected call of CommentError
-func (mr *MockClientMockRecorder) CommentError(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) CommentError(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommentError", reflect.TypeOf((*MockClient)(nil).CommentError), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommentError", reflect.TypeOf((*MockClient)(nil).CommentError), arg0, arg1, arg2, arg3)
 }
 
 // ErrorStatus mocks base method
-func (m *MockClient) ErrorStatus(arg0, arg1, arg2, arg3, arg4 string, arg5 *errors.Error) *errors.Error {
+func (m *MockClient) ErrorStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string, arg6 *errors.Error) *errors.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ErrorStatus", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "ErrorStatus", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(*errors.Error)
 	return ret0
 }
 
 // ErrorStatus indicates an expected call of ErrorStatus
-func (mr *MockClientMockRecorder) ErrorStatus(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ErrorStatus(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErrorStatus", reflect.TypeOf((*MockClient)(nil).ErrorStatus), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErrorStatus", reflect.TypeOf((*MockClient)(nil).ErrorStatus), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // FinishedStatus mocks base method
-func (m *MockClient) FinishedStatus(arg0, arg1, arg2, arg3, arg4 string, arg5 bool, arg6 string) *errors.Error {
+func (m *MockClient) FinishedStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string, arg6 bool, arg7 string) *errors.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FinishedStatus", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "FinishedStatus", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(*errors.Error)
 	return ret0
 }
 
 // FinishedStatus indicates an expected call of FinishedStatus
-func (mr *MockClientMockRecorder) FinishedStatus(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) FinishedStatus(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishedStatus", reflect.TypeOf((*MockClient)(nil).FinishedStatus), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishedStatus", reflect.TypeOf((*MockClient)(nil).FinishedStatus), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // GetDiffFiles mocks base method
-func (m *MockClient) GetDiffFiles(arg0, arg1, arg2 string) ([]string, *errors.Error) {
+func (m *MockClient) GetDiffFiles(arg0 context.Context, arg1, arg2, arg3 string) ([]string, *errors.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDiffFiles", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetDiffFiles", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(*errors.Error)
 	return ret0, ret1
 }
 
 // GetDiffFiles indicates an expected call of GetDiffFiles
-func (mr *MockClientMockRecorder) GetDiffFiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetDiffFiles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiffFiles", reflect.TypeOf((*MockClient)(nil).GetDiffFiles), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiffFiles", reflect.TypeOf((*MockClient)(nil).GetDiffFiles), arg0, arg1, arg2, arg3)
 }
 
 // GetFile mocks base method
-func (m *MockClient) GetFile(arg0, arg1, arg2 string) ([]byte, *errors.Error) {
+func (m *MockClient) GetFile(arg0 context.Context, arg1, arg2, arg3 string) ([]byte, *errors.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFile", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetFile", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(*errors.Error)
 	return ret0, ret1
 }
 
 // GetFile indicates an expected call of GetFile
-func (mr *MockClientMockRecorder) GetFile(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetFile(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFile", reflect.TypeOf((*MockClient)(nil).GetFile), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFile", reflect.TypeOf((*MockClient)(nil).GetFile), arg0, arg1, arg2, arg3)
 }
 
 // GetFileList mocks base method
-func (m *MockClient) GetFileList(arg0, arg1 string) ([]string, *errors.Error) {
+func (m *MockClient) GetFileList(arg0 context.Context, arg1, arg2 string) ([]string, *errors.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileList", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetFileList", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(*errors.Error)
 	return ret0, ret1
 }
 
 // GetFileList indicates an expected call of GetFileList
-func (mr *MockClientMockRecorder) GetFileList(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetFileList(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileList", reflect.TypeOf((*MockClient)(nil).GetFileList), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileList", reflect.TypeOf((*MockClient)(nil).GetFileList), arg0, arg1, arg2)
 }
 
 // GetRefs mocks base method
-func (m *MockClient) GetRefs(arg0, arg1 string) ([]string, *errors.Error) {
+func (m *MockClient) GetRefs(arg0 context.Context, arg1, arg2 string) ([]string, *errors.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRefs", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetRefs", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(*errors.Error)
 	return ret0, ret1
 }
 
 // GetRefs indicates an expected call of GetRefs
-func (mr *MockClientMockRecorder) GetRefs(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetRefs(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRefs", reflect.TypeOf((*MockClient)(nil).GetRefs), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRefs", reflect.TypeOf((*MockClient)(nil).GetRefs), arg0, arg1, arg2)
 }
 
 // GetRepository mocks base method
-func (m *MockClient) GetRepository(arg0 string) (*github.Repository, *errors.Error) {
+func (m *MockClient) GetRepository(arg0 context.Context, arg1 string) (*github.Repository, *errors.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRepository", arg0)
+	ret := m.ctrl.Call(m, "GetRepository", arg0, arg1)
 	ret0, _ := ret[0].(*github.Repository)
 	ret1, _ := ret[1].(*errors.Error)
 	return ret0, ret1
 }
 
 // GetRepository indicates an expected call of GetRepository
-func (mr *MockClientMockRecorder) GetRepository(arg0 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetRepository(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepository", reflect.TypeOf((*MockClient)(nil).GetRepository), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepository", reflect.TypeOf((*MockClient)(nil).GetRepository), arg0, arg1)
 }
 
 // GetSHA mocks base method
-func (m *MockClient) GetSHA(arg0, arg1 string) (string, *errors.Error) {
+func (m *MockClient) GetSHA(arg0 context.Context, arg1, arg2 string) (string, *errors.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSHA", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetSHA", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(*errors.Error)
 	return ret0, ret1
 }
 
 // GetSHA indicates an expected call of GetSHA
-func (mr *MockClientMockRecorder) GetSHA(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetSHA(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSHA", reflect.TypeOf((*MockClient)(nil).GetSHA), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSHA", reflect.TypeOf((*MockClient)(nil).GetSHA), arg0, arg1, arg2)
 }
 
 // MyLogin mocks base method
-func (m *MockClient) MyLogin() (string, *errors.Error) {
+func (m *MockClient) MyLogin(arg0 context.Context) (string, *errors.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MyLogin")
+	ret := m.ctrl.Call(m, "MyLogin", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(*errors.Error)
 	return ret0, ret1
 }
 
 // MyLogin indicates an expected call of MyLogin
-func (mr *MockClientMockRecorder) MyLogin() *gomock.Call {
+func (mr *MockClientMockRecorder) MyLogin(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MyLogin", reflect.TypeOf((*MockClient)(nil).MyLogin))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MyLogin", reflect.TypeOf((*MockClient)(nil).MyLogin), arg0)
 }
 
 // MyRepositories mocks base method
-func (m *MockClient) MyRepositories() ([]*github.Repository, *errors.Error) {
+func (m *MockClient) MyRepositories(arg0 context.Context) ([]*github.Repository, *errors.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MyRepositories")
+	ret := m.ctrl.Call(m, "MyRepositories", arg0)
 	ret0, _ := ret[0].([]*github.Repository)
 	ret1, _ := ret[1].(*errors.Error)
 	return ret0, ret1
 }
 
 // MyRepositories indicates an expected call of MyRepositories
-func (mr *MockClientMockRecorder) MyRepositories() *gomock.Call {
+func (mr *MockClientMockRecorder) MyRepositories(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MyRepositories", reflect.TypeOf((*MockClient)(nil).MyRepositories))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MyRepositories", reflect.TypeOf((*MockClient)(nil).MyRepositories), arg0)
 }
 
 // PendingStatus mocks base method
-func (m *MockClient) PendingStatus(arg0, arg1, arg2, arg3, arg4 string) *errors.Error {
+func (m *MockClient) PendingStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) *errors.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PendingStatus", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "PendingStatus", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*errors.Error)
 	return ret0
 }
 
 // PendingStatus indicates an expected call of PendingStatus
-func (mr *MockClientMockRecorder) PendingStatus(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) PendingStatus(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PendingStatus", reflect.TypeOf((*MockClient)(nil).PendingStatus), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PendingStatus", reflect.TypeOf((*MockClient)(nil).PendingStatus), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // SetupHook mocks base method
-func (m *MockClient) SetupHook(arg0, arg1, arg2, arg3 string) *errors.Error {
+func (m *MockClient) SetupHook(arg0 context.Context, arg1, arg2, arg3, arg4 string) *errors.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetupHook", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SetupHook", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*errors.Error)
 	return ret0
 }
 
 // SetupHook indicates an expected call of SetupHook
-func (mr *MockClientMockRecorder) SetupHook(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) SetupHook(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupHook", reflect.TypeOf((*MockClient)(nil).SetupHook), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupHook", reflect.TypeOf((*MockClient)(nil).SetupHook), arg0, arg1, arg2, arg3, arg4)
 }
 
 // StartedStatus mocks base method
-func (m *MockClient) StartedStatus(arg0, arg1, arg2, arg3, arg4 string) *errors.Error {
+func (m *MockClient) StartedStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) *errors.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartedStatus", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "StartedStatus", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*errors.Error)
 	return ret0
 }
 
 // StartedStatus indicates an expected call of StartedStatus
-func (mr *MockClientMockRecorder) StartedStatus(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) StartedStatus(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartedStatus", reflect.TypeOf((*MockClient)(nil).StartedStatus), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartedStatus", reflect.TypeOf((*MockClient)(nil).StartedStatus), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // TeardownHook mocks base method
-func (m *MockClient) TeardownHook(arg0, arg1, arg2 string) *errors.Error {
+func (m *MockClient) TeardownHook(arg0 context.Context, arg1, arg2, arg3 string) *errors.Error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TeardownHook", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "TeardownHook", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*errors.Error)
 	return ret0
 }
 
 // TeardownHook indicates an expected call of TeardownHook
-func (mr *MockClientMockRecorder) TeardownHook(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) TeardownHook(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeardownHook", reflect.TypeOf((*MockClient)(nil).TeardownHook), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeardownHook", reflect.TypeOf((*MockClient)(nil).TeardownHook), arg0, arg1, arg2, arg3)
 }

--- a/model/cancel_test.go
+++ b/model/cancel_test.go
@@ -18,7 +18,7 @@ func (ms *modelSuite) TestCancellationByRef(c *check.C) {
 		owner, repo, err := qi.Run.Task.Parent.OwnerRepo()
 		c.Assert(err, check.IsNil)
 
-		client.EXPECT().ErrorStatus(owner, repo, qi.Run.Name, qi.Run.Task.Ref.SHA, fmt.Sprintf("__test__/log/%d", qi.Run.ID), errors.ErrRunCanceled).Return(nil)
+		client.EXPECT().ErrorStatus(gomock.Any(), owner, repo, qi.Run.Name, qi.Run.Task.Ref.SHA, fmt.Sprintf("__test__/log/%d", qi.Run.ID), errors.ErrRunCanceled).Return(nil)
 		c.Assert(ms.model.CancelRefByName(qi.Run.Task.Ref.Repository.ID, qi.Run.Task.Ref.RefName, "__test__", client), check.IsNil)
 
 		runs, err := ms.model.GetRunsForTask(qi.Run.Task.ID, 0, 100)
@@ -39,7 +39,7 @@ func (ms *modelSuite) TestCancellationByTask(c *check.C) {
 		owner, repo, err := qi.Run.Task.Parent.OwnerRepo()
 		c.Assert(err, check.IsNil)
 
-		client.EXPECT().ErrorStatus(owner, repo, qi.Run.Name, qi.Run.Task.Ref.SHA, fmt.Sprintf("__test__/log/%d", qi.Run.ID), errors.ErrRunCanceled).Return(nil)
+		client.EXPECT().ErrorStatus(gomock.Any(), owner, repo, qi.Run.Name, qi.Run.Task.Ref.SHA, fmt.Sprintf("__test__/log/%d", qi.Run.ID), errors.ErrRunCanceled).Return(nil)
 		c.Assert(ms.model.CancelTask(qi.Run.Task, "__test__", client), check.IsNil)
 
 		runs, err := ms.model.GetRunsForTask(qi.Run.Task.ID, 0, 100)
@@ -60,7 +60,7 @@ func (ms *modelSuite) TestCancellationByRun(c *check.C) {
 		owner, repo, err := qi.Run.Task.Parent.OwnerRepo()
 		c.Assert(err, check.IsNil)
 
-		client.EXPECT().ErrorStatus(owner, repo, qi.Run.Name, qi.Run.Task.Ref.SHA, fmt.Sprintf("__test__/log/%d", qi.Run.ID), errors.ErrRunCanceled).Return(nil)
+		client.EXPECT().ErrorStatus(gomock.Any(), owner, repo, qi.Run.Name, qi.Run.Task.Ref.SHA, fmt.Sprintf("__test__/log/%d", qi.Run.ID), errors.ErrRunCanceled).Return(nil)
 		c.Assert(ms.model.CancelRun(qi.Run.ID, "__test__", client), check.IsNil)
 
 		runs, err := ms.model.GetRunsForTask(qi.Run.Task.ID, 0, 100)

--- a/model/run.go
+++ b/model/run.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -179,13 +180,13 @@ func (m *Model) SetRunStatus(runID int64, gh github.Client, status, canceled boo
 
 	if canceled {
 		go func() {
-			if err := bits.github.ErrorStatus(bits.parts[0], bits.parts[1], bits.run.Name, bits.run.Task.Ref.SHA, fmt.Sprintf("%s/log/%d", url, runID), errors.ErrRunCanceled); err != nil {
+			if err := bits.github.ErrorStatus(context.Background(), bits.parts[0], bits.parts[1], bits.run.Name, bits.run.Task.Ref.SHA, fmt.Sprintf("%s/log/%d", url, runID), errors.ErrRunCanceled); err != nil {
 				fmt.Println(err) // FIXME log
 			}
 		}()
 	} else {
 		go func() {
-			if err := bits.github.FinishedStatus(bits.parts[0], bits.parts[1], bits.run.Name, bits.run.Task.Ref.SHA, fmt.Sprintf("%s/log/%d", url, runID), status, addlMessage); err != nil {
+			if err := bits.github.FinishedStatus(context.Background(), bits.parts[0], bits.parts[1], bits.run.Name, bits.run.Task.Ref.SHA, fmt.Sprintf("%s/log/%d", url, runID), status, addlMessage); err != nil {
 				fmt.Println(err)
 			}
 		}()

--- a/model/submission_test.go
+++ b/model/submission_test.go
@@ -304,7 +304,7 @@ func (ms *modelSuite) TestSubmissionTasks(c *check.C) {
 					runCount += count
 
 					for i := int64(0); i < count; i++ {
-						gh.EXPECT().ErrorStatus(owner, repo, "default", task.Ref.SHA, gomock.Any(), gomock.Any())
+						gh.EXPECT().ErrorStatus(gomock.Any(), owner, repo, "default", task.Ref.SHA, gomock.Any(), gomock.Any())
 					}
 				}
 

--- a/testutil/testclients/queuesvc.go
+++ b/testutil/testclients/queuesvc.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/golang/mock/gomock"
 	gh "github.com/google/go-github/github"
 	"github.com/tinyci/ci-agents/clients/queue"
 	"github.com/tinyci/ci-agents/config"
@@ -66,30 +67,30 @@ func (qc *QueueClient) SetMockSubmissionOnFork(mock *github.MockClientMockRecord
 		return err
 	}
 
-	mock.GetRepository(sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
-	mock.GetSHA(sub.Fork, "heads/master").Return(resolvedSHA, nil)
-	mock.GetSHA(sub.Fork, "heads/master").Return(resolvedSHA, nil)
-	mock.ClearStates(sub.Fork, resolvedSHA).Return(nil)
-	mock.GetRepository(sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
-	mock.GetRefs(sub.Fork, resolvedSHA).Return([]string{"heads/master"}, nil)
-	mock.GetRefs(sub.Fork, resolvedSHA).Return([]string{"heads/master"}, nil)
-	mock.GetDiffFiles(sub.Fork, resolvedSHA, resolvedSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar"}, nil)
-	mock.GetFileList(sub.Fork, resolvedSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
-	mock.GetRepository(sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
-	mock.GetRepository(sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
-	mock.GetRepository(sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
-	mock.GetRepository(sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
-	mock.GetFile(sub.Fork, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
+	mock.GetSHA(gomock.Any(), sub.Fork, "heads/master").Return(resolvedSHA, nil)
+	mock.GetSHA(gomock.Any(), sub.Fork, "heads/master").Return(resolvedSHA, nil)
+	mock.ClearStates(gomock.Any(), sub.Fork, resolvedSHA).Return(nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
+	mock.GetRefs(gomock.Any(), sub.Fork, resolvedSHA).Return([]string{"heads/master"}, nil)
+	mock.GetRefs(gomock.Any(), sub.Fork, resolvedSHA).Return([]string{"heads/master"}, nil)
+	mock.GetDiffFiles(gomock.Any(), sub.Fork, resolvedSHA, resolvedSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar"}, nil)
+	mock.GetFileList(gomock.Any(), sub.Fork, resolvedSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
+	mock.GetFile(gomock.Any(), sub.Fork, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
 
-	mock.GetFile(sub.Fork, resolvedSHA, "bar/task.yml").Return(taskBytes, nil)
-	mock.GetFile(sub.Fork, resolvedSHA, "foo/task.yml").Return(taskBytes, nil)
-	mock.GetFile(sub.Fork, resolvedSHA, "task.yml").Return(taskBytes, nil)
+	mock.GetFile(gomock.Any(), sub.Fork, resolvedSHA, "bar/task.yml").Return(taskBytes, nil)
+	mock.GetFile(gomock.Any(), sub.Fork, resolvedSHA, "foo/task.yml").Return(taskBytes, nil)
+	mock.GetFile(gomock.Any(), sub.Fork, resolvedSHA, "task.yml").Return(taskBytes, nil)
 
 	parts := strings.SplitN(sub.Fork, "/", 2)
 
 	for _, name := range []string{"*root*", "foo", "bar"} {
 		for x := 1; x <= 5; x++ {
-			mock.PendingStatus(parts[0], parts[1], fmt.Sprintf("%s:%d", name, x), resolvedSHA, "url")
+			mock.PendingStatus(gomock.Any(), parts[0], parts[1], fmt.Sprintf("%s:%d", name, x), resolvedSHA, "url")
 		}
 	}
 
@@ -112,25 +113,25 @@ func (qc *QueueClient) SetMockSubmissionSuccess(mock *github.MockClientMockRecor
 		sub.Parent = sub.Fork
 	}
 
-	mock.GetRepository(sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(sub.Parent)}}, nil)
-	mock.GetRepository(sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
-	mock.GetRepository(sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(sub.Parent)}}, nil)
-	mock.GetRefs(sub.Fork, sub.HeadSHA).Return([]string{"heads/fork-branch"}, nil)
-	mock.GetRefs(sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil)
-	mock.GetDiffFiles(sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar"}, nil)
-	mock.GetFileList(sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
-	mock.GetRepository(sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
-	mock.GetFile(sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(sub.Parent)}}, nil)
+	mock.GetRepository(gomock.Any(), sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(sub.Parent)}}, nil)
+	mock.GetRefs(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"heads/fork-branch"}, nil)
+	mock.GetRefs(gomock.Any(), sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil)
+	mock.GetDiffFiles(gomock.Any(), sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar"}, nil)
+	mock.GetFileList(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
+	mock.GetRepository(gomock.Any(), sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
+	mock.GetFile(gomock.Any(), sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
 
-	mock.GetFile(sub.Fork, sub.HeadSHA, "bar/task.yml").Return(taskBytes, nil)
-	mock.GetFile(sub.Fork, sub.HeadSHA, "foo/task.yml").Return(taskBytes, nil)
-	mock.GetFile(sub.Fork, sub.HeadSHA, "task.yml").Return(taskBytes, nil)
+	mock.GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "bar/task.yml").Return(taskBytes, nil)
+	mock.GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "foo/task.yml").Return(taskBytes, nil)
+	mock.GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "task.yml").Return(taskBytes, nil)
 
 	parts := strings.SplitN(sub.Parent, "/", 2)
 
 	for _, name := range []string{"*root*", "foo", "bar"} {
 		for x := 1; x <= 5; x++ {
-			mock.PendingStatus(parts[0], parts[1], fmt.Sprintf("%s:%d", name, x), sub.HeadSHA, "url")
+			mock.PendingStatus(gomock.Any(), parts[0], parts[1], fmt.Sprintf("%s:%d", name, x), sub.HeadSHA, "url")
 		}
 	}
 


### PR DESCRIPTION
Long time coming. Now, github API calls will appropriately terminate
early when the connection is closed on the HTTP end.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>