### PR TITLE
Github readonly client mode

### DIFF
--- a/clients/github/task.yml
+++ b/clients/github/task.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - ci-gen

--- a/config/service.go
+++ b/config/service.go
@@ -51,6 +51,7 @@ type UserConfig struct {
 	Port           uint        `yaml:"port"`
 	URL            string      `yaml:"url"`
 	EnableTracing  bool        `yaml:"enable_tracing"`
+	ReadonlyClient bool        `yaml:"readonly_client"`
 }
 
 // Service is the internal configuration for a service
@@ -123,11 +124,14 @@ func (cc *ClientConfig) Validate() *errors.Error {
 	return cc.Cert.Validate()
 }
 
-// CreateClients creates all the clients that are populated in the clients struct
+// CreateClients creates all the clients that are populated in the clients
+// struct. It will also tweak any settings for the github client.
 func (cc *ClientConfig) CreateClients(uc UserConfig, service string) (*Clients, *errors.Error) {
 	if err := cc.Validate(); err != nil {
 		return nil, err
 	}
+
+	github.Readonly = uc.ReadonlyClient
 
 	clientCert, err := cc.Cert.Load()
 	if err != nil {


### PR DESCRIPTION
This allows certain workflows with integration tests we want to do, but
ultimately just disallows API requests for certain actions based on a
setting called `readonly_client`, which may be present in the
configuration. If supplied, things like status updates, hook settings
and other "write to github" operations will be nullified, allowing the
system to continue to work otherwise.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>