### PR TITLE
Fix errors.Error use throughout the stack by removing pointer assignment

### DIFF
--- a/api/assetsvc/log.go
+++ b/api/assetsvc/log.go
@@ -49,7 +49,7 @@ func (as *AssetServer) GetLog(id *types.IntID, ag asset.Asset_GetLogServer) erro
 func (as *AssetServer) submit(ap asset.Asset_PutLogServer, p string) (retErr error) {
 	defer func() {
 		if retErr != nil {
-			retErr = errors.New(retErr).ToGRPC(codes.FailedPrecondition)
+			retErr = errors.New(retErr).(errors.Error).ToGRPC(codes.FailedPrecondition)
 			md := metadata.New(nil)
 			md.Append("errors", retErr.Error())
 			ap.SetTrailer(md)
@@ -106,7 +106,7 @@ func write(ag asset.Asset_GetLogServer, buf []byte) error {
 func (as *AssetServer) attach(id int64, ag asset.Asset_GetLogServer, p string) (retErr error) {
 	defer func() {
 		if retErr != nil {
-			retErr = errors.New(retErr).ToGRPC(codes.FailedPrecondition)
+			retErr = errors.New(retErr).(errors.Error).ToGRPC(codes.FailedPrecondition)
 		} else {
 			retErr = write(ag, []byte(color.New(color.FgGreen).Sprintln("---- LOG COMPLETE ----")))
 		}

--- a/api/assetsvc/testserver.go
+++ b/api/assetsvc/testserver.go
@@ -11,7 +11,7 @@ import (
 
 // MakeAssetServer makes an instance of the assetsvc on port 6000. It returns a
 // chan which can be closed to terminate it, and any boot-time errors.
-func MakeAssetServer() (*handler.H, chan struct{}, *errors.Error) {
+func MakeAssetServer() (*handler.H, chan struct{}, error) {
 	t, err := transport.Listen(nil, "tcp", config.DefaultServices.Asset.String())
 	if err != nil {
 		return nil, nil, errors.New(err)

--- a/api/auth/github/github.go
+++ b/api/auth/github/github.go
@@ -35,7 +35,7 @@ func (as *AuthServer) Capabilities(ctx context.Context, e *empty.Empty) (*auth.S
 func (as *AuthServer) OAuthChallenge(ctx context.Context, ocr *auth.OAuthChallengeRequest) (*auth.OAuthInfo, error) {
 	scopes, eErr := as.H.Clients.Data.OAuthValidateState(ctx, ocr.State)
 	if eErr != nil {
-		return nil, eErr.Wrap("Locating state").ToGRPC(codes.FailedPrecondition)
+		return nil, eErr.(errors.Error).Wrap("Locating state").ToGRPC(codes.FailedPrecondition)
 	}
 
 	conf := as.H.OAuth.Config(scopes)
@@ -44,12 +44,12 @@ func (as *AuthServer) OAuthChallenge(ctx context.Context, ocr *auth.OAuthChallen
 	if err != nil {
 		switch err.(type) {
 		case *oauth2.RetrieveError:
-			return nil, errors.New(err).Wrap("exchanging code for a token").ToGRPC(codes.FailedPrecondition)
+			return nil, errors.New(err).(errors.Error).Wrap("exchanging code for a token").ToGRPC(codes.FailedPrecondition)
 		default:
 			as.H.Clients.Log.Error(ctx, err)
 			url, err := as.makeOAuthURL(ctx, scopes)
 			if err != nil {
-				return nil, err.ToGRPC(codes.FailedPrecondition)
+				return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 			}
 
 			return &auth.OAuthInfo{Url: url, Redirect: true}, nil
@@ -60,7 +60,7 @@ func (as *AuthServer) OAuthChallenge(ctx context.Context, ocr *auth.OAuthChallen
 	c := github.NewClient(client)
 	u, _, err := c.Users.Get(ctx, "")
 	if err != nil {
-		return nil, errors.New(err).Wrap("Looking up token user").ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).Wrap("Looking up token user").ToGRPC(codes.FailedPrecondition)
 	}
 
 	user, eErr := as.H.Clients.Data.GetUser(ctx, u.GetLogin())
@@ -74,23 +74,23 @@ func (as *AuthServer) OAuthChallenge(ctx context.Context, ocr *auth.OAuthChallen
 	if eErr != nil { // same check as above; to determine whether to add or patch
 		user, eErr = as.H.Clients.Data.PutUser(ctx, user)
 		if eErr != nil {
-			return nil, eErr.Wrapf("Could not create user %v", u.GetLogin()).ToGRPC(codes.FailedPrecondition)
+			return nil, eErr.(errors.Error).Wrapf("Could not create user %v", u.GetLogin()).ToGRPC(codes.FailedPrecondition)
 		}
 	} else {
 		if err := as.H.Clients.Data.PatchUser(ctx, user); err != nil {
-			return nil, eErr.Wrapf("Could not patch user %v", u.GetLogin()).ToGRPC(codes.FailedPrecondition)
+			return nil, eErr.(errors.Error).Wrapf("Could not patch user %v", u.GetLogin()).ToGRPC(codes.FailedPrecondition)
 		}
 	}
 
 	return &auth.OAuthInfo{Username: user.Username}, nil
 }
 
-func (as *AuthServer) makeOAuthURL(ctx context.Context, scopes []string) (string, *errors.Error) {
+func (as *AuthServer) makeOAuthURL(ctx context.Context, scopes []string) (string, error) {
 	conf := as.H.OAuth.Config(scopes)
 	state := strings.TrimRight(base32.StdEncoding.EncodeToString(securecookie.GenerateRandomKey(64)), "=")
 
 	if err := as.H.Clients.Data.OAuthRegisterState(ctx, state, scopes); err != nil {
-		return "", err.Wrap("registering state")
+		return "", err.(errors.Error).Wrap("registering state")
 	}
 
 	return conf.AuthCodeURL(
@@ -103,7 +103,7 @@ func (as *AuthServer) makeOAuthURL(ctx context.Context, scopes []string) (string
 func (as *AuthServer) GetOAuthURL(ctx context.Context, scopes *auth.Scopes) (*auth.String, error) {
 	url, err := as.makeOAuthURL(ctx, scopes.List)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &auth.String{Str: url}, nil

--- a/api/datasvc/errors.go
+++ b/api/datasvc/errors.go
@@ -14,7 +14,7 @@ import (
 func (ds *DataServer) GetErrors(ctx context.Context, name *data.Name) (*types.UserErrors, error) {
 	u, err := ds.H.Model.FindUserByName(name.Name)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	errors := &types.UserErrors{}
@@ -29,13 +29,13 @@ func (ds *DataServer) GetErrors(ctx context.Context, name *data.Name) (*types.Us
 func (ds *DataServer) AddError(ctx context.Context, ue *types.UserError) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByID(ue.UserID)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	u.AddError(errors.New(ue.Error))
 
 	if err := ds.H.Model.Save(u).Error; err != nil {
-		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -45,11 +45,11 @@ func (ds *DataServer) AddError(ctx context.Context, ue *types.UserError) (*empty
 func (ds *DataServer) DeleteError(ctx context.Context, ue *types.UserError) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByID(ue.UserID)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.DeleteError(u, ue.Id); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil

--- a/api/datasvc/oauth.go
+++ b/api/datasvc/oauth.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/services/data"
+	"github.com/tinyci/ci-agents/errors"
 	"google.golang.org/grpc/codes"
 )
 
@@ -13,7 +14,7 @@ import (
 // to us.
 func (ds *DataServer) OAuthRegisterState(ctx context.Context, oas *data.OAuthState) (*empty.Empty, error) {
 	if err := ds.H.Model.OAuthRegisterState(oas.State, oas.Scopes); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -25,7 +26,7 @@ func (ds *DataServer) OAuthRegisterState(ctx context.Context, oas *data.OAuthSta
 func (ds *DataServer) OAuthValidateState(ctx context.Context, oas *data.OAuthState) (*data.OAuthState, error) {
 	o, err := ds.H.Model.OAuthValidateState(oas.State)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return o.ToProto(), nil

--- a/api/datasvc/ref.go
+++ b/api/datasvc/ref.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tinyci/ci-agents/ci-gen/grpc/services/data"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/types"
 	"github.com/tinyci/ci-agents/config"
+	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/model"
 	"google.golang.org/grpc/codes"
 )
@@ -15,7 +16,7 @@ import (
 func (ds *DataServer) GetRefByNameAndSHA(ctx context.Context, rp *data.RefPair) (*types.Ref, error) {
 	ref, err := ds.H.Model.GetRefByNameAndSHA(rp.RepoName, rp.Sha)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 	return ref.ToProto(), nil
 }
@@ -24,11 +25,11 @@ func (ds *DataServer) GetRefByNameAndSHA(ctx context.Context, rp *data.RefPair) 
 func (ds *DataServer) PutRef(ctx context.Context, ref *types.Ref) (*types.Ref, error) {
 	ret, err := model.NewRefFromProto(ref)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.PutRef(ret); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return ret.ToProto(), nil
@@ -39,7 +40,7 @@ func (ds *DataServer) PutRef(ctx context.Context, ref *types.Ref) (*types.Ref, e
 // cancel runs as new ones are being submitted.
 func (ds *DataServer) CancelRefByName(ctx context.Context, rr *data.RepoRef) (*empty.Empty, error) {
 	if err := ds.H.Model.CancelRefByName(rr.Repository, rr.RefName, ds.H.URL, config.DefaultGithubClient()); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil

--- a/api/datasvc/repository.go
+++ b/api/datasvc/repository.go
@@ -17,20 +17,20 @@ import (
 func (ds *DataServer) EnableRepository(ctx context.Context, rus *data.RepoUserSelection) (*empty.Empty, error) {
 	user, err := ds.H.Model.FindUserByName(rus.Username)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	repo, err := ds.H.Model.GetRepositoryByNameForUser(rus.RepoName, user)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.AddSubscriptionsForUser(user, model.RepositoryList{repo}); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.EnableRepository(repo, user); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -40,16 +40,16 @@ func (ds *DataServer) EnableRepository(ctx context.Context, rus *data.RepoUserSe
 func (ds *DataServer) DisableRepository(ctx context.Context, rus *data.RepoUserSelection) (*empty.Empty, error) {
 	user, err := ds.H.Model.FindUserByName(rus.Username)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	repo, err := ds.H.Model.GetRepositoryByNameForUser(rus.RepoName, user)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.DisableRepository(repo); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -60,11 +60,11 @@ func (ds *DataServer) SaveRepositories(ctx context.Context, gh *data.GithubJSON)
 	repos := []*github.Repository{}
 
 	if err := json.Unmarshal(gh.JSON, &repos); err != nil {
-		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.SaveRepositories(repos, gh.Username, gh.AutoCreated); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -74,12 +74,12 @@ func (ds *DataServer) SaveRepositories(ctx context.Context, gh *data.GithubJSON)
 func (ds *DataServer) PrivateRepositories(ctx context.Context, nameSearch *data.NameSearch) (*types.RepositoryList, error) {
 	u, err := ds.H.Model.FindUserByName(nameSearch.Name)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	repos, err := ds.H.Model.GetPrivateReposForUser(u, nameSearch.Search)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return model.RepositoryList(repos).ToProto(), nil
@@ -89,12 +89,12 @@ func (ds *DataServer) PrivateRepositories(ctx context.Context, nameSearch *data.
 func (ds *DataServer) OwnedRepositories(ctx context.Context, nameSearch *data.NameSearch) (*types.RepositoryList, error) {
 	u, err := ds.H.Model.FindUserByName(nameSearch.Name)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	repos, err := ds.H.Model.GetOwnedRepos(u, nameSearch.Search)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return model.RepositoryList(repos).ToProto(), nil
@@ -104,12 +104,12 @@ func (ds *DataServer) OwnedRepositories(ctx context.Context, nameSearch *data.Na
 func (ds *DataServer) AllRepositories(ctx context.Context, nameSearch *data.NameSearch) (*types.RepositoryList, error) {
 	u, err := ds.H.Model.FindUserByName(nameSearch.Name)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	repos, err := ds.H.Model.GetVisibleReposForUser(u, nameSearch.Search)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return model.RepositoryList(repos).ToProto(), nil
@@ -119,7 +119,7 @@ func (ds *DataServer) AllRepositories(ctx context.Context, nameSearch *data.Name
 func (ds *DataServer) PublicRepositories(ctx context.Context, search *data.Search) (*types.RepositoryList, error) {
 	repos, err := ds.H.Model.GetAllPublicRepos(search.Search)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return model.RepositoryList(repos).ToProto(), nil
@@ -129,7 +129,7 @@ func (ds *DataServer) PublicRepositories(ctx context.Context, search *data.Searc
 func (ds *DataServer) GetRepository(ctx context.Context, name *data.Name) (*types.Repository, error) {
 	repo, err := ds.H.Model.GetRepositoryByName(name.Name)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return repo.ToProto(), nil

--- a/api/datasvc/run.go
+++ b/api/datasvc/run.go
@@ -20,25 +20,25 @@ func (ds *DataServer) RunCount(ctx context.Context, rp *data.RefPair) (*data.Cou
 	if rp.RepoName != "" {
 		repo, err := ds.H.Model.GetRepositoryByName(rp.RepoName)
 		if err != nil {
-			return nil, err.ToGRPC(codes.FailedPrecondition)
+			return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 		}
 
 		if rp.Sha != "" {
 			res, err = ds.H.Model.RunTotalCountForRepositoryAndSHA(repo, rp.Sha)
 			if err != nil {
-				return nil, err.ToGRPC(codes.FailedPrecondition)
+				return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 			}
 		} else {
 			res, err = ds.H.Model.RunTotalCountForRepository(repo)
 			if err != nil {
-				return nil, err.ToGRPC(codes.FailedPrecondition)
+				return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 			}
 		}
 	} else {
-		var err *errors.Error
+		var err error
 		res, err = ds.H.Model.RunTotalCount()
 		if err != nil {
-			return nil, err.ToGRPC(codes.FailedPrecondition)
+			return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 		}
 	}
 
@@ -49,12 +49,12 @@ func (ds *DataServer) RunCount(ctx context.Context, rp *data.RefPair) (*data.Cou
 func (ds *DataServer) RunList(ctx context.Context, rq *data.RunListRequest) (*types.RunList, error) {
 	page, perPage, err := utils.ScopePaginationInt(rq.Page, rq.PerPage)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	list, err := ds.H.Model.RunList(page, perPage, rq.Repository, rq.Sha)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	ret := &types.RunList{}
@@ -71,7 +71,7 @@ func (ds *DataServer) GetRun(ctx context.Context, id *types.IntID) (*types.Run, 
 	run := &model.Run{}
 
 	if err := ds.H.Model.Preload("Task.Parent").Where("id = ?", id.ID).First(run).Error; err != nil {
-		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return run.ToProto(), nil
@@ -82,7 +82,7 @@ func (ds *DataServer) GetRunUI(ctx context.Context, id *types.IntID) (*types.Run
 	run := &model.Run{}
 
 	if err := ds.H.Model.Where("id = ?", id.ID).First(run).Error; err != nil {
-		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return run.ToProto(), nil

--- a/api/datasvc/sessions.go
+++ b/api/datasvc/sessions.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/types"
+	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/model"
 	"google.golang.org/grpc/codes"
 )
@@ -12,7 +13,7 @@ import (
 // PutSession saves a session created for a user.
 func (ds *DataServer) PutSession(ctx context.Context, s *types.Session) (*empty.Empty, error) {
 	if err := ds.H.Model.SaveSession(model.NewSessionFromProto(s)); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -22,7 +23,7 @@ func (ds *DataServer) PutSession(ctx context.Context, s *types.Session) (*empty.
 func (ds *DataServer) LoadSession(ctx context.Context, id *types.StringID) (*types.Session, error) {
 	s, err := ds.H.Model.LoadSession(id.ID)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return s.ToProto(), nil

--- a/api/datasvc/submission.go
+++ b/api/datasvc/submission.go
@@ -15,7 +15,7 @@ import (
 func (ds *DataServer) GetSubmission(ctx context.Context, id *types.IntID) (*types.Submission, error) {
 	s, err := ds.H.Model.GetSubmissionByID(id.ID)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return s.ToProto(), nil
@@ -25,12 +25,12 @@ func (ds *DataServer) GetSubmission(ctx context.Context, id *types.IntID) (*type
 func (ds *DataServer) GetSubmissionRuns(ctx context.Context, sub *data.SubmissionQuery) (*types.RunList, error) {
 	protoSub, err := model.NewSubmissionFromProto(sub.Submission)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	runs, err := ds.H.Model.RunsForSubmission(protoSub, sub.Page, sub.PerPage)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	rl := &types.RunList{}
@@ -46,12 +46,12 @@ func (ds *DataServer) GetSubmissionRuns(ctx context.Context, sub *data.Submissio
 func (ds *DataServer) GetSubmissionTasks(ctx context.Context, sub *data.SubmissionQuery) (*types.TaskList, error) {
 	protoSub, err := model.NewSubmissionFromProto(sub.Submission)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	tasks, err := ds.H.Model.TasksForSubmission(protoSub, sub.Page, sub.PerPage)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	tl := &types.TaskList{}
@@ -67,11 +67,11 @@ func (ds *DataServer) GetSubmissionTasks(ctx context.Context, sub *data.Submissi
 func (ds *DataServer) PutSubmission(ctx context.Context, sub *types.Submission) (*types.Submission, error) {
 	s, err := model.NewSubmissionFromProto(sub)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.Create(s).Error; err != nil {
-		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return s.ToProto(), nil
@@ -81,7 +81,7 @@ func (ds *DataServer) PutSubmission(ctx context.Context, sub *types.Submission) 
 func (ds *DataServer) ListSubmissions(ctx context.Context, req *data.RepositoryFilterRequestWithPagination) (*types.SubmissionList, error) {
 	list, err := ds.H.Model.SubmissionList(req.Page, req.PerPage, req.Repository, req.Sha)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	newList := &types.SubmissionList{}
@@ -97,7 +97,7 @@ func (ds *DataServer) ListSubmissions(ctx context.Context, req *data.RepositoryF
 func (ds *DataServer) CountSubmissions(ctx context.Context, req *data.RepositoryFilterRequest) (*data.Count, error) {
 	count, err := ds.H.Model.SubmissionCount(req.Repository, req.Sha)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &data.Count{Count: count}, nil
@@ -108,7 +108,7 @@ func (ds *DataServer) CancelSubmission(ctx context.Context, id *types.IntID) (*e
 	empty := &empty.Empty{}
 
 	if err := ds.H.Model.CancelSubmissionByID(id.ID, ds.H.URL, nil); err != nil {
-		return empty, err.ToGRPC(codes.FailedPrecondition)
+		return empty, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return empty, nil

--- a/api/datasvc/subscriptions.go
+++ b/api/datasvc/subscriptions.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/services/data"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/types"
+	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/model"
 	"google.golang.org/grpc/codes"
 )
@@ -14,16 +15,16 @@ import (
 func (ds *DataServer) RemoveSubscription(ctx context.Context, rus *data.RepoUserSelection) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByName(rus.Username)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	r, err := ds.H.Model.GetRepositoryByNameForUser(rus.RepoName, u)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.RemoveSubscriptionForUser(u, r); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -33,16 +34,16 @@ func (ds *DataServer) RemoveSubscription(ctx context.Context, rus *data.RepoUser
 func (ds *DataServer) AddSubscription(ctx context.Context, rus *data.RepoUserSelection) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByName(rus.Username)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	r, err := ds.H.Model.GetRepositoryByNameForUser(rus.RepoName, u)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.AddSubscriptionsForUser(u, []*model.Repository{r}); err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -52,7 +53,7 @@ func (ds *DataServer) AddSubscription(ctx context.Context, rus *data.RepoUserSel
 func (ds *DataServer) ListSubscriptions(ctx context.Context, nameSearch *data.NameSearch) (*types.RepositoryList, error) {
 	u, err := ds.H.Model.FindUserByNameWithSubscriptions(nameSearch.Name, nameSearch.Search)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return model.RepositoryList(u.Subscribed).ToProto(), nil

--- a/api/datasvc/task.go
+++ b/api/datasvc/task.go
@@ -14,7 +14,7 @@ import (
 // CancelTask cancels a task by ID.
 func (ds *DataServer) CancelTask(ctx context.Context, id *types.IntID) (*empty.Empty, error) {
 	if err := ds.H.Model.CancelTaskByID(id.ID, ds.H.UserConfig.URL, nil); err != nil {
-		return nil, err.Wrapf("could not cancel runs for for task_id %d", id.ID)
+		return nil, err.(errors.Error).Wrapf("could not cancel runs for for task_id %d", id.ID)
 	}
 
 	return &empty.Empty{}, nil
@@ -23,7 +23,7 @@ func (ds *DataServer) CancelTask(ctx context.Context, id *types.IntID) (*empty.E
 // CancelTasksByPR cancels multiple tasks by Pull Request ID.
 func (ds *DataServer) CancelTasksByPR(ctx context.Context, prq *types.CancelPRRequest) (*empty.Empty, error) {
 	if err := ds.H.Model.CancelTasksForPR(prq.Repository, prq.Id, ds.H.URL); err != nil {
-		return nil, err.Wrapf("Could not cancel tasks for repo %q, PR #%d", prq.Repository, prq.Id).ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).Wrapf("Could not cancel tasks for repo %q, PR #%d", prq.Repository, prq.Id).ToGRPC(codes.FailedPrecondition)
 	}
 	return &empty.Empty{}, nil
 }
@@ -36,7 +36,7 @@ func (ds *DataServer) PutTask(ctx context.Context, task *types.Task) (*types.Tas
 	}
 
 	if err := ds.H.Model.Create(t).Error; err != nil {
-		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return t.ToProto(), nil
@@ -46,7 +46,7 @@ func (ds *DataServer) PutTask(ctx context.Context, task *types.Task) (*types.Tas
 func (ds *DataServer) ListTasks(ctx context.Context, req *data.TaskListRequest) (*types.TaskList, error) {
 	tasks, err := ds.H.Model.ListTasks(req.Repository, req.Sha, req.Page, req.PerPage)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	retTasks := &types.TaskList{}
@@ -62,7 +62,7 @@ func (ds *DataServer) ListTasks(ctx context.Context, req *data.TaskListRequest) 
 func (ds *DataServer) CountTasks(ctx context.Context, req *data.TaskListRequest) (*data.Count, error) {
 	count, err := ds.H.Model.CountTasks(req.Repository, req.Sha)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &data.Count{Count: count}, nil
@@ -72,7 +72,7 @@ func (ds *DataServer) CountTasks(ctx context.Context, req *data.TaskListRequest)
 func (ds *DataServer) RunsForTask(ctx context.Context, req *data.RunsForTaskRequest) (*types.RunList, error) {
 	runs, err := ds.H.Model.GetRunsForTask(req.Id, req.Page, req.PerPage)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	rl := &types.RunList{}
@@ -88,7 +88,7 @@ func (ds *DataServer) RunsForTask(ctx context.Context, req *data.RunsForTaskRequ
 func (ds *DataServer) CountRunsForTask(ctx context.Context, id *types.IntID) (*data.Count, error) {
 	count, err := ds.H.Model.CountRunsForTask(id.ID)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &data.Count{Count: count}, nil
@@ -98,7 +98,7 @@ func (ds *DataServer) CountRunsForTask(ctx context.Context, id *types.IntID) (*d
 func (ds *DataServer) ListSubscribedTasksForUser(ctx context.Context, lstr *data.ListSubscribedTasksRequest) (*types.TaskList, error) {
 	tasks, err := ds.H.Model.ListSubscribedTasksForUser(lstr.Id, lstr.Page, lstr.PerPage)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 	grpcTask := &types.TaskList{}
 

--- a/api/datasvc/testserver.go
+++ b/api/datasvc/testserver.go
@@ -12,7 +12,7 @@ import (
 
 // MakeDataServer makes an instance of the datasvc on port 6000. It returns a
 // chan which can be closed to terminate it, and any boot-time errors.
-func MakeDataServer() (*handler.H, chan struct{}, *errors.Error) {
+func MakeDataServer() (*handler.H, chan struct{}, error) {
 	h := &handler.H{
 		Service: config.Service{
 			UseDB: true,

--- a/api/datasvc/token.go
+++ b/api/datasvc/token.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/services/data"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/types"
+	"github.com/tinyci/ci-agents/errors"
 	"google.golang.org/grpc/codes"
 )
 
@@ -18,7 +19,7 @@ import (
 func (ds *DataServer) GetToken(ctx context.Context, name *data.Name) (*types.StringID, error) {
 	token, err := ds.H.Model.GetToken(name.Name)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &types.StringID{ID: token}, nil
@@ -28,7 +29,7 @@ func (ds *DataServer) GetToken(ctx context.Context, name *data.Name) (*types.Str
 func (ds *DataServer) DeleteToken(ctx context.Context, name *data.Name) (*empty.Empty, error) {
 	err := ds.H.Model.DeleteToken(name.Name)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -38,7 +39,7 @@ func (ds *DataServer) DeleteToken(ctx context.Context, name *data.Name) (*empty.
 func (ds *DataServer) ValidateToken(ctx context.Context, id *types.StringID) (*types.User, error) {
 	u, err := ds.H.Model.ValidateToken(id.ID)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return u.ToProto(), nil

--- a/api/datasvc/user.go
+++ b/api/datasvc/user.go
@@ -17,7 +17,7 @@ import (
 func (ds *DataServer) UserByName(ctx context.Context, name *data.Name) (*types.User, error) {
 	user, err := ds.H.Model.FindUserByName(name.Name)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return user.ToProto(), nil
@@ -28,18 +28,18 @@ func (ds *DataServer) UserByName(ctx context.Context, name *data.Name) (*types.U
 func (ds *DataServer) PatchUser(ctx context.Context, u *types.User) (*empty.Empty, error) {
 	origUser, err := ds.H.Model.FindUserByName(u.Username)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	newUser, err := model.NewUserFromProto(u)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	// for now this is the only edit possible. :)
 	origUser.Token = newUser.Token
 	if err := ds.H.Model.Save(origUser).Error; err != nil {
-		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -49,13 +49,13 @@ func (ds *DataServer) PatchUser(ctx context.Context, u *types.User) (*empty.Empt
 func (ds *DataServer) PutUser(ctx context.Context, u *types.User) (*types.User, error) {
 	ot := &topTypes.OAuthToken{}
 	if err := json.Unmarshal(u.TokenJSON, ot); err != nil {
-		return &types.User{}, errors.New(err).ToGRPC(codes.FailedPrecondition)
+		return &types.User{}, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	um, err := ds.H.Model.CreateUser(u.Username, ot)
 	if err != nil {
 		ds.H.Clients.Log.Errorf(ctx, "Could not create user %q: %v", u.Username, err)
-		return &types.User{}, err.ToGRPC(codes.FailedPrecondition)
+		return &types.User{}, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	ds.H.Clients.Log.Infof(ctx, "Created user %q", u.Username)
@@ -68,7 +68,7 @@ func (ds *DataServer) ListUsers(ctx context.Context, e *empty.Empty) (*types.Use
 	list := []*model.User{}
 
 	if err := ds.H.Model.Find(&list).Error; err != nil {
-		return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	tu := &types.UserList{}
@@ -84,12 +84,12 @@ func (ds *DataServer) ListUsers(ctx context.Context, e *empty.Empty) (*types.Use
 func (ds *DataServer) HasCapability(ctx context.Context, cr *data.CapabilityRequest) (*types.Bool, error) {
 	u, err := ds.H.Model.FindUserByID(cr.Id)
 	if err != nil {
-		return &types.Bool{Result: false}, err.ToGRPC(codes.FailedPrecondition)
+		return &types.Bool{Result: false}, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	res, err := ds.H.Model.HasCapability(u, model.Capability(cr.Capability), ds.H.Auth.FixedCapabilities)
 	if err != nil {
-		return &types.Bool{Result: false}, err.ToGRPC(codes.FailedPrecondition)
+		return &types.Bool{Result: false}, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &types.Bool{Result: res}, nil
@@ -99,11 +99,11 @@ func (ds *DataServer) HasCapability(ctx context.Context, cr *data.CapabilityRequ
 func (ds *DataServer) AddCapability(ctx context.Context, cr *data.CapabilityRequest) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByID(cr.Id)
 	if err != nil {
-		return &empty.Empty{}, err.ToGRPC(codes.FailedPrecondition)
+		return &empty.Empty{}, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.AddCapabilityToUser(u, model.Capability(cr.Capability)); err != nil {
-		return &empty.Empty{}, err.ToGRPC(codes.FailedPrecondition)
+		return &empty.Empty{}, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -113,11 +113,11 @@ func (ds *DataServer) AddCapability(ctx context.Context, cr *data.CapabilityRequ
 func (ds *DataServer) RemoveCapability(ctx context.Context, cr *data.CapabilityRequest) (*empty.Empty, error) {
 	u, err := ds.H.Model.FindUserByID(cr.Id)
 	if err != nil {
-		return &empty.Empty{}, err.ToGRPC(codes.FailedPrecondition)
+		return &empty.Empty{}, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if err := ds.H.Model.RemoveCapabilityFromUser(u, model.Capability(cr.Capability)); err != nil {
-		return &empty.Empty{}, err.ToGRPC(codes.FailedPrecondition)
+		return &empty.Empty{}, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -127,12 +127,12 @@ func (ds *DataServer) RemoveCapability(ctx context.Context, cr *data.CapabilityR
 func (ds *DataServer) GetCapabilities(ctx context.Context, u *types.User) (*data.Capabilities, error) {
 	mu, err := model.NewUserFromProto(u)
 	if err != nil {
-		return &data.Capabilities{}, err.ToGRPC(codes.FailedPrecondition)
+		return &data.Capabilities{}, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	caps, err := ds.H.Model.GetCapabilities(mu, ds.H.Auth.FixedCapabilities)
 	if err != nil {
-		return &data.Capabilities{}, err.ToGRPC(codes.FailedPrecondition)
+		return &data.Capabilities{}, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	strCaps := []string{}

--- a/api/hooksvc/hooksvc.go
+++ b/api/hooksvc/hooksvc.go
@@ -66,7 +66,7 @@ type Handler struct {
 }
 
 // Init initializes the handler.
-func (h *Handler) Init() *errors.Error {
+func (h *Handler) Init() error {
 	cert, err := h.Config.TLS.Load()
 	if err != nil {
 		return err

--- a/api/logsvc/submit.go
+++ b/api/logsvc/submit.go
@@ -15,7 +15,7 @@ import (
 func (ls *LogServer) Put(ctx context.Context, lm *log.LogMessage) (*empty.Empty, error) {
 	dispatcher, ok := ls.DispatchTable[lm.GetLevel()]
 	if !ok {
-		return &empty.Empty{}, errors.Errorf("Invalid log level %q", lm.GetLevel()).ToGRPC(codes.FailedPrecondition)
+		return &empty.Empty{}, errors.Errorf("Invalid log level %q", lm.GetLevel()).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	fields := map[string]interface{}{}
@@ -25,7 +25,7 @@ func (ls *LogServer) Put(ctx context.Context, lm *log.LogMessage) (*empty.Empty,
 		case *_struct.Value_StringValue:
 			fields[key] = kind.StringValue
 		default:
-			return &empty.Empty{}, errors.Errorf("%q must be a string value", key).ToGRPC(codes.FailedPrecondition)
+			return &empty.Empty{}, errors.Errorf("%q must be a string value", key).(errors.Error).ToGRPC(codes.FailedPrecondition)
 		}
 	}
 

--- a/api/logsvc/testserver.go
+++ b/api/logsvc/testserver.go
@@ -11,7 +11,7 @@ import (
 )
 
 // MakeLogServer makes a logsvc.
-func MakeLogServer() (*handler.H, chan struct{}, *LogJournal, *errors.Error) {
+func MakeLogServer() (*handler.H, chan struct{}, *LogJournal, error) {
 	journal := &LogJournal{Journal: map[string][]*log.LogMessage{}}
 
 	logDispatch := DispatchTable{

--- a/api/queuesvc/task_picker.go
+++ b/api/queuesvc/task_picker.go
@@ -23,7 +23,7 @@ func (sp *submissionProcessor) newTaskPicker() *taskPicker {
 	return &taskPicker{handler: sp.handler, logger: sp.logger}
 }
 
-func (tp *taskPicker) pick(ctx context.Context, sub *types.Submission, repoInfo *repoInfo) ([]*model.QueueItem, *errors.Error) {
+func (tp *taskPicker) pick(ctx context.Context, sub *types.Submission, repoInfo *repoInfo) ([]*model.QueueItem, error) {
 	process := map[string]struct{}{}
 
 	mb := repoInfo.parent.Github.GetMasterBranch()
@@ -33,7 +33,7 @@ func (tp *taskPicker) pick(ctx context.Context, sub *types.Submission, repoInfo 
 
 	dirs, taskdirs, err := tp.toProcess(ctx, repoInfo)
 	if err != nil {
-		return nil, err.Wrap("determining what to process")
+		return nil, err.(errors.Error).Wrap("determining what to process")
 	}
 
 	if (sub.All && sub.Manual) || (repoInfo.forkRef.Repository.ID == repoInfo.parent.ID && repoInfo.parentRef.RefName == mb) {
@@ -45,19 +45,19 @@ func (tp *taskPicker) pick(ctx context.Context, sub *types.Submission, repoInfo 
 	}
 
 	if err := tp.cancelPreviousRuns(ctx, repoInfo); err != nil {
-		return nil, err.Wrap("while canceling the previous runs")
+		return nil, err.(errors.Error).Wrap("while canceling the previous runs")
 	}
 
 	subRecord, err := tp.handler.Clients.Data.PutSubmission(ctx, &model.Submission{TicketID: repoInfo.ticketID, User: repoInfo.user, HeadRef: repoInfo.forkRef, BaseRef: repoInfo.parentRef})
 	if err != nil {
-		return nil, err.Wrap("couldn't convert submission")
+		return nil, err.(errors.Error).Wrap("couldn't convert submission")
 	}
 
 	// XXX reusing taskdirs here because it serves the same purpose, albeit
 	// slightly different form here.
 	tasks, taskdirs, err := tp.makeTaskDirs(ctx, process, subRecord, repoInfo)
 	if err != nil {
-		return nil, err.Wrap("computing task directories")
+		return nil, err.(errors.Error).Wrap("computing task directories")
 	}
 
 	queueCreateTime := time.Now()
@@ -75,7 +75,7 @@ func (tp *taskPicker) pick(ctx context.Context, sub *types.Submission, repoInfo 
 
 		tmpQIs, err := tp.generateQueueItems(ctx, dir, task, repoInfo)
 		if err != nil {
-			return nil, err.Wrap("generating queue items")
+			return nil, err.(errors.Error).Wrap("generating queue items")
 		}
 
 		qis = append(qis, tmpQIs...)
@@ -85,15 +85,15 @@ func (tp *taskPicker) pick(ctx context.Context, sub *types.Submission, repoInfo 
 	return qis, nil
 }
 
-func (tp *taskPicker) getDiffFiles(ctx context.Context, repoInfo *repoInfo) (map[string]struct{}, []string, *errors.Error) {
+func (tp *taskPicker) getDiffFiles(ctx context.Context, repoInfo *repoInfo) (map[string]struct{}, []string, error) {
 	client, err := repoInfo.client(tp.handler)
 	if err != nil {
-		return nil, nil, err.Wrap("obtaining parent owner's client")
+		return nil, nil, err.(errors.Error).Wrap("obtaining parent owner's client")
 	}
 
 	diffFiles, err := client.GetDiffFiles(ctx, repoInfo.parent.Name, repoInfo.parentRef.SHA, repoInfo.forkRef.SHA)
 	if err != nil {
-		return nil, nil, err.Wrap("getting file list for diff")
+		return nil, nil, err.(errors.Error).Wrap("getting file list for diff")
 	}
 
 	dirs := map[string]struct{}{}
@@ -110,7 +110,7 @@ func (tp *taskPicker) getDiffFiles(ctx context.Context, repoInfo *repoInfo) (map
 	return dirs, allFiles, nil
 }
 
-func (tp *taskPicker) toProcess(ctx context.Context, repoInfo *repoInfo) (map[string]struct{}, []string, *errors.Error) {
+func (tp *taskPicker) toProcess(ctx context.Context, repoInfo *repoInfo) (map[string]struct{}, []string, error) {
 	dirs, allFiles, err := tp.getDiffFiles(ctx, repoInfo)
 	if err != nil {
 		return nil, nil, err
@@ -169,14 +169,14 @@ func (tp *taskPicker) selectTasks(dirs map[string]struct{}, taskdirs []string) m
 	return process
 }
 
-func (tp *taskPicker) cancelPreviousRuns(ctx context.Context, repoInfo *repoInfo) *errors.Error {
+func (tp *taskPicker) cancelPreviousRuns(ctx context.Context, repoInfo *repoInfo) error {
 	if err := tp.handler.Clients.Data.CancelRefByName(ctx, repoInfo.forkRef.Repository.ID, repoInfo.forkRef.RefName); err != nil {
 		tp.logger.Errorf(ctx, "Couldn't cancel ref %q repo %d; will continue anyway: %v\n", repoInfo.forkRef.RefName, repoInfo.parent.ID, err)
 	}
 
 	client, err := repoInfo.client(tp.handler)
 	if err != nil {
-		return err.Wrap("could not retrieve parent owner's github client")
+		return err.(errors.Error).Wrap("could not retrieve parent owner's github client")
 	}
 
 	if err := client.ClearStates(ctx, repoInfo.parent.Name, repoInfo.forkRef.SHA); err != nil {
@@ -186,26 +186,26 @@ func (tp *taskPicker) cancelPreviousRuns(ctx context.Context, repoInfo *repoInfo
 	return nil
 }
 
-func (tp *taskPicker) makeTask(ctx context.Context, subRecord *model.Submission, dir string, repoInfo *repoInfo) (*model.Task, *errors.Error) {
+func (tp *taskPicker) makeTask(ctx context.Context, subRecord *model.Submission, dir string, repoInfo *repoInfo) (*model.Task, error) {
 	client, err := repoInfo.client(tp.handler)
 	if err != nil {
-		return nil, err.Wrapf("obtaining client for parent owner")
+		return nil, err.(errors.Error).Wrapf("obtaining client for parent owner")
 	}
 
 	content, err := client.GetFile(ctx, repoInfo.fork.Name, repoInfo.forkRef.SHA, path.Join(dir, taskConfigFilename))
 	if err != nil {
-		return nil, err.Wrapf("obtaining task instructions for repo %q sha %q dir %q", repoInfo.fork.Name, repoInfo.forkRef.SHA, dir)
+		return nil, err.(errors.Error).Wrapf("obtaining task instructions for repo %q sha %q dir %q", repoInfo.fork.Name, repoInfo.forkRef.SHA, dir)
 	}
 
 	ts, err := types.NewTaskSettings(content, false, repoInfo.repoConfig)
 	if err != nil {
 		if repoInfo.ticketID != 0 {
-			if cerr := client.CommentError(ctx, repoInfo.parent.Name, repoInfo.ticketID, err.Wrap("tinyCI had an error processing your pull request")); cerr != nil {
-				return nil, cerr.Wrap("attempting to alert the user about the error in their pull request")
+			if cerr := client.CommentError(ctx, repoInfo.parent.Name, repoInfo.ticketID, err.(errors.Error).Wrap("tinyCI had an error processing your pull request")); cerr != nil {
+				return nil, cerr.(errors.Error).Wrap("attempting to alert the user about the error in their pull request")
 			}
 		}
 
-		return nil, err.Wrapf("validating task settings for repo %q sha %q dir %q", repoInfo.fork.Name, repoInfo.forkRef.SHA, dir)
+		return nil, err.(errors.Error).Wrapf("validating task settings for repo %q sha %q dir %q", repoInfo.fork.Name, repoInfo.forkRef.SHA, dir)
 	}
 
 	return &model.Task{
@@ -216,7 +216,7 @@ func (tp *taskPicker) makeTask(ctx context.Context, subRecord *model.Submission,
 	}, nil
 }
 
-func (tp *taskPicker) makeTaskDirs(ctx context.Context, process map[string]struct{}, subRecord *model.Submission, repoInfo *repoInfo) (map[string]*model.Task, []string, *errors.Error) {
+func (tp *taskPicker) makeTaskDirs(ctx context.Context, process map[string]struct{}, subRecord *model.Submission, repoInfo *repoInfo) (map[string]*model.Task, []string, error) {
 	tasks := map[string]*model.Task{}
 
 	tp.logger.Info(ctx, "Computing task dirs")
@@ -229,7 +229,7 @@ func (tp *taskPicker) makeTaskDirs(ctx context.Context, process map[string]struc
 	for i := 0; i < len(taskdirs); i++ {
 		task, err := tp.makeTask(ctx, subRecord, taskdirs[i], repoInfo)
 		if err != nil {
-			return nil, nil, err.Wrap("making task")
+			return nil, nil, err.(errors.Error).Wrap("making task")
 		}
 
 		tasks[taskdirs[i]] = task
@@ -246,12 +246,12 @@ func (tp *taskPicker) makeTaskDirs(ctx context.Context, process map[string]struc
 	return tasks, taskdirs, nil
 }
 
-func (tp *taskPicker) generateQueueItems(ctx context.Context, dir string, task *model.Task, repoInfo *repoInfo) ([]*model.QueueItem, *errors.Error) {
+func (tp *taskPicker) generateQueueItems(ctx context.Context, dir string, task *model.Task, repoInfo *repoInfo) ([]*model.QueueItem, error) {
 	qis := []*model.QueueItem{}
 
 	task, err := tp.handler.Clients.Data.PutTask(ctx, task)
 	if err != nil {
-		return nil, err.Wrap("Could not insert task")
+		return nil, err.(errors.Error).Wrap("Could not insert task")
 	}
 
 	names := []string{}
@@ -265,7 +265,7 @@ func (tp *taskPicker) generateQueueItems(ctx context.Context, dir string, task *
 	for _, name := range names {
 		qi, err := tp.makeRunQueue(ctx, name, dir, task, repoInfo)
 		if err != nil {
-			return nil, err.Wrap("constructing queue item")
+			return nil, err.(errors.Error).Wrap("constructing queue item")
 		}
 		qis = append(qis, qi)
 	}
@@ -273,7 +273,7 @@ func (tp *taskPicker) generateQueueItems(ctx context.Context, dir string, task *
 	return qis, nil
 }
 
-func (tp *taskPicker) makeRunQueue(ctx context.Context, name, dir string, task *model.Task, repoInfo *repoInfo) (*model.QueueItem, *errors.Error) {
+func (tp *taskPicker) makeRunQueue(ctx context.Context, name, dir string, task *model.Task, repoInfo *repoInfo) (*model.QueueItem, error) {
 	rs := task.TaskSettings.Runs[name]
 
 	dirStr := dir
@@ -305,10 +305,10 @@ func (tp *taskPicker) setPendingStatus(ctx context.Context, run *model.Run, repo
 
 	client, err := repoInfo.client(tp.handler)
 	if err != nil {
-		tp.logger.Error(ctx, err.Wrap("could not obtain client for parent owner"))
+		tp.logger.Error(ctx, err.(errors.Error).Wrap("could not obtain client for parent owner"))
 	}
 
 	if err := client.PendingStatus(ctx, parts[0], parts[1], run.Name, repoInfo.forkRef.SHA, tp.handler.URL); err != nil {
-		tp.logger.Error(ctx, err.Wrap("could not set pending status"))
+		tp.logger.Error(ctx, err.(errors.Error).Wrap("could not set pending status"))
 	}
 }

--- a/api/queuesvc/testserver.go
+++ b/api/queuesvc/testserver.go
@@ -12,7 +12,7 @@ import (
 
 // MakeQueueServer makes an instance of the queuesvc on port 6001. It returns a
 // chan which can be closed to terminate it, and any boot-time errors.
-func MakeQueueServer() (*handler.H, chan struct{}, *errors.Error) {
+func MakeQueueServer() (*handler.H, chan struct{}, error) {
 	h := &handler.H{
 		Service: config.Service{
 			Name: "queuesvc",

--- a/api/repository/github/git.go
+++ b/api/repository/github/git.go
@@ -14,17 +14,17 @@ import (
 func (rs *RepositoryServer) GetFileList(ctx context.Context, rsp *repository.RepoSHAPair) (*repository.StringList, error) {
 	owner, repo, err := utils.OwnerRepo(rsp.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	gh, err := rs.getClientForRepo(ctx, rsp.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	tree, _, eErr := gh.Git.GetTree(ctx, owner, repo, rsp.Sha, true)
 	if eErr != nil {
-		return nil, errors.New(err).Wrapf("obtaining tree for repo %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).Wrapf("obtaining tree for repo %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
 	}
 
 	files := []string{}
@@ -40,17 +40,17 @@ func (rs *RepositoryServer) GetFileList(ctx context.Context, rsp *repository.Rep
 func (rs *RepositoryServer) GetSHA(ctx context.Context, rrp *repository.RepoRefPair) (*repository.String, error) {
 	owner, repo, err := utils.OwnerRepo(rrp.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	gh, err := rs.getClientForRepo(ctx, rrp.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	ref, _, eErr := gh.Git.GetRef(ctx, owner, repo, rrp.RefName)
 	if eErr != nil {
-		return nil, errors.New(eErr).Wrapf("Obtaining ref for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(eErr).(errors.Error).Wrapf("Obtaining ref for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &repository.String{Name: ref.GetObject().GetSHA()}, nil
@@ -60,18 +60,18 @@ func (rs *RepositoryServer) GetSHA(ctx context.Context, rrp *repository.RepoRefP
 func (rs *RepositoryServer) GetRefs(ctx context.Context, rsp *repository.RepoSHAPair) (*repository.StringList, error) {
 	owner, repo, err := utils.OwnerRepo(rsp.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	gh, err := rs.getClientForRepo(ctx, rsp.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	// FIXME pagination (sigh)
 	refs, _, eErr := gh.Git.ListRefs(ctx, owner, repo, nil)
 	if eErr != nil {
-		return nil, errors.New(eErr).Wrapf("listing refs for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(eErr).(errors.Error).Wrapf("listing refs for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
 	}
 
 	list := []string{}
@@ -89,34 +89,34 @@ func (rs *RepositoryServer) GetRefs(ctx context.Context, rsp *repository.RepoSHA
 func (rs *RepositoryServer) GetFile(ctx context.Context, fr *repository.FileRequest) (*repository.Bytes, error) {
 	owner, repo, err := utils.OwnerRepo(fr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	gh, err := rs.getClientForRepo(ctx, fr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	tree, _, eErr := gh.Git.GetTree(ctx, owner, repo, fr.Sha, true)
 	if eErr != nil {
-		return nil, errors.New(eErr).Wrapf("getting tree for repo %v/%v (sha: %v)", owner, repo, fr.Sha).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(eErr).(errors.Error).Wrapf("getting tree for repo %v/%v (sha: %v)", owner, repo, fr.Sha).ToGRPC(codes.FailedPrecondition)
 	}
 
 	for _, entry := range tree.Entries {
 		if entry.GetPath() == fr.Filename {
 			content, _, err := gh.Git.GetBlobRaw(context.Background(), owner, repo, entry.GetSHA())
 			if err != nil {
-				return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+				return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 			}
 
 			return &repository.Bytes{Value: content}, nil
 		}
 	}
 
-	return nil, errors.New("file not found").ToGRPC(codes.FailedPrecondition)
+	return nil, errors.New("file not found").(errors.Error).ToGRPC(codes.FailedPrecondition)
 }
 
-func (rs *RepositoryServer) getFileList(ctx context.Context, repoName, sha string) ([]string, *errors.Error) {
+func (rs *RepositoryServer) getFileList(ctx context.Context, repoName, sha string) ([]string, error) {
 	owner, repo, err := utils.OwnerRepo(repoName)
 	if err != nil {
 		return nil, err
@@ -145,30 +145,30 @@ func (rs *RepositoryServer) getFileList(ctx context.Context, repoName, sha strin
 func (rs *RepositoryServer) GetDiffFiles(ctx context.Context, fdr *repository.FileDiffRequest) (*repository.StringList, error) {
 	owner, repo, err := utils.OwnerRepo(fdr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	if fdr.Base == strings.Repeat("0", 40) {
 		list, err := rs.getFileList(ctx, fdr.RepoName, fdr.Head)
 		if err != nil {
-			return nil, err.ToGRPC(codes.FailedPrecondition)
+			return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 		}
 
 		return &repository.StringList{List: list}, nil
 	}
 
 	if fdr.Head == strings.Repeat("0", 40) {
-		return nil, errors.New("branch deleted").ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New("branch deleted").(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	gh, err := rs.getClientForRepo(ctx, fdr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	commits, _, eErr := gh.Repositories.CompareCommits(ctx, owner, repo, fdr.Base, fdr.Head)
 	if eErr != nil {
-		return nil, errors.New(eErr).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(eErr).(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	files := []string{}

--- a/api/repository/github/github.go
+++ b/api/repository/github/github.go
@@ -6,7 +6,6 @@ import (
 	"github.com/google/go-github/github"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/handler"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/types"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/model"
 	"golang.org/x/oauth2"
 )
@@ -16,7 +15,7 @@ type RepositoryServer struct {
 	H *handler.H
 }
 
-func (rs *RepositoryServer) getClientForRepo(ctx context.Context, repoName string) (*github.Client, *errors.Error) {
+func (rs *RepositoryServer) getClientForRepo(ctx context.Context, repoName string) (*github.Client, error) {
 	repo, err := rs.H.Clients.Data.GetRepository(ctx, repoName)
 	if err != nil {
 		return nil, err
@@ -30,7 +29,7 @@ func (rs *RepositoryServer) getClientForRepo(ctx context.Context, repoName strin
 	return github.NewClient(tc), nil
 }
 
-func (rs *RepositoryServer) getClientForUser(ctx context.Context, u *types.User) (*github.Client, *errors.Error) {
+func (rs *RepositoryServer) getClientForUser(ctx context.Context, u *types.User) (*github.Client, error) {
 	user, err := model.NewUserFromProto(u)
 	if err != nil {
 		return nil, err

--- a/api/repository/github/hook.go
+++ b/api/repository/github/hook.go
@@ -15,12 +15,12 @@ import (
 func (rs *RepositoryServer) SetupHook(ctx context.Context, hsr *repository.HookSetupRequest) (*empty.Empty, error) {
 	owner, repo, err := utils.OwnerRepo(hsr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	gh, err := rs.getClientForRepo(ctx, hsr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	_, _, eErr := gh.Repositories.CreateHook(ctx, owner, repo, &github.Hook{
@@ -35,7 +35,7 @@ func (rs *RepositoryServer) SetupHook(ctx context.Context, hsr *repository.HookS
 	})
 
 	if eErr != nil {
-		return nil, errors.New(eErr).Wrapf("configuring hook on repo %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(eErr).(errors.Error).Wrapf("configuring hook on repo %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -45,12 +45,12 @@ func (rs *RepositoryServer) SetupHook(ctx context.Context, hsr *repository.HookS
 func (rs *RepositoryServer) TeardownHook(ctx context.Context, htr *repository.HookTeardownRequest) (*empty.Empty, error) {
 	owner, repo, err := utils.OwnerRepo(htr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	gh, err := rs.getClientForRepo(ctx, htr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	var id int64
@@ -74,7 +74,7 @@ finish:
 	if id != 0 {
 		_, err := gh.Repositories.DeleteHook(context.Background(), owner, repo, id)
 		if err != nil {
-			return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+			return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 		}
 	}
 

--- a/api/repository/github/repositories.go
+++ b/api/repository/github/repositories.go
@@ -20,7 +20,7 @@ func (rs *RepositoryServer) MyRepositories(ctx context.Context, user *types.User
 
 	gh, err := rs.getClientForUser(ctx, user)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	for {
@@ -73,17 +73,17 @@ func (rs *RepositoryServer) MyRepositories(ctx context.Context, user *types.User
 func (rs *RepositoryServer) GetRepository(ctx context.Context, uwn *repository.UserWithRepo) (*repository.RepositoryData, error) {
 	owner, repo, err := utils.OwnerRepo(uwn.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	gh, err := rs.getClientForUser(ctx, uwn.User)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	r, _, eErr := gh.Repositories.Get(ctx, owner, repo)
 	if eErr != nil {
-		return nil, errors.New(eErr).Wrapf("Could not fetch repository %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(eErr).(errors.Error).Wrapf("Could not fetch repository %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
 	}
 
 	outRepo := &repository.RepositoryData{

--- a/api/repository/github/status.go
+++ b/api/repository/github/status.go
@@ -16,11 +16,11 @@ import (
 func (rs *RepositoryServer) CommentError(ctx context.Context, cer *repository.CommentErrorRequest) (*empty.Empty, error) {
 	owner, repo, retErr := utils.OwnerRepo(cer.RepoName)
 	if retErr != nil {
-		return nil, retErr.ToGRPC(codes.FailedPrecondition)
+		return nil, retErr.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 	gh, err := rs.getClientForRepo(ctx, cer.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	_, _, eerr := gh.Issues.CreateComment(ctx, owner, repo, int(cer.PrID), &github.IssueComment{
@@ -34,7 +34,7 @@ func (rs *RepositoryServer) CommentError(ctx context.Context, cer *repository.Co
 	return &empty.Empty{}, nil
 }
 
-func (rs *RepositoryServer) getStatusInfo(ctx context.Context, repoName string) (*github.Client, string, string, *errors.Error) {
+func (rs *RepositoryServer) getStatusInfo(ctx context.Context, repoName string) (*github.Client, string, string, error) {
 	owner, repo, err := utils.OwnerRepo(repoName)
 	if err != nil {
 		return nil, "", "", err
@@ -52,7 +52,7 @@ func (rs *RepositoryServer) getStatusInfo(ctx context.Context, repoName string) 
 func (rs *RepositoryServer) PendingStatus(ctx context.Context, sr *repository.StatusRequest) (*empty.Empty, error) {
 	gh, owner, repo, err := rs.getStatusInfo(ctx, sr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	_, _, eErr := gh.Repositories.CreateStatus(ctx, owner, repo, sr.Sha, &github.RepoStatus{
@@ -62,7 +62,7 @@ func (rs *RepositoryServer) PendingStatus(ctx context.Context, sr *repository.St
 		Context:     github.String(sr.RunName),
 	})
 	if eErr != nil {
-		return nil, errors.New(eErr).Wrapf("creating status for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(eErr).(errors.Error).Wrapf("creating status for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -72,7 +72,7 @@ func (rs *RepositoryServer) PendingStatus(ctx context.Context, sr *repository.St
 func (rs *RepositoryServer) StartedStatus(ctx context.Context, sr *repository.StatusRequest) (*empty.Empty, error) {
 	gh, owner, repo, err := rs.getStatusInfo(ctx, sr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	_, _, eErr := gh.Repositories.CreateStatus(ctx, owner, repo, sr.Sha, &github.RepoStatus{
@@ -82,7 +82,7 @@ func (rs *RepositoryServer) StartedStatus(ctx context.Context, sr *repository.St
 		Context:     github.String(sr.RunName),
 	})
 	if eErr != nil {
-		return nil, errors.New(eErr).Wrapf("creating status for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(eErr).(errors.Error).Wrapf("creating status for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -100,18 +100,18 @@ func capStatus(str string) *string {
 func (rs *RepositoryServer) ErrorStatus(ctx context.Context, esr *repository.ErrorStatusRequest) (*empty.Empty, error) {
 	gh, owner, repo, err := rs.getStatusInfo(ctx, esr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	_, _, eErr := gh.Repositories.CreateStatus(ctx, owner, repo, esr.Sha, &github.RepoStatus{
 		TargetURL: github.String(esr.Url),
 		State:     github.String("error"),
 		// github statuses cap at 140c
-		Description: capStatus(errors.New(esr.Error).Wrap("The run encountered an error").Error()),
+		Description: capStatus(errors.New(esr.Error).(errors.Error).Wrap("The run encountered an error").Error()),
 		Context:     github.String(esr.RunName),
 	})
 	if eErr != nil {
-		return nil, errors.New(eErr).Wrapf("creating status for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(eErr).(errors.Error).Wrapf("creating status for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -121,7 +121,7 @@ func (rs *RepositoryServer) ErrorStatus(ctx context.Context, esr *repository.Err
 func (rs *RepositoryServer) FinishedStatus(ctx context.Context, fsr *repository.FinishedStatusRequest) (*empty.Empty, error) {
 	gh, owner, repo, err := rs.getStatusInfo(ctx, fsr.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	statusString := "failure"
@@ -137,7 +137,7 @@ func (rs *RepositoryServer) FinishedStatus(ctx context.Context, fsr *repository.
 		Context:     github.String(fsr.RunName),
 	})
 	if eErr != nil {
-		return nil, errors.New(eErr).Wrapf("creating status for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(eErr).(errors.Error).Wrapf("creating status for %v/%v", owner, repo).ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &empty.Empty{}, nil
@@ -148,7 +148,7 @@ func (rs *RepositoryServer) FinishedStatus(ctx context.Context, fsr *repository.
 func (rs *RepositoryServer) ClearStates(ctx context.Context, rsp *repository.RepoSHAPair) (*empty.Empty, error) {
 	gh, owner, repo, err := rs.getStatusInfo(ctx, rsp.RepoName)
 	if err != nil {
-		return nil, err.ToGRPC(codes.FailedPrecondition)
+		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
 	statuses := []*github.RepoStatus{}
@@ -158,7 +158,7 @@ func (rs *RepositoryServer) ClearStates(ctx context.Context, rsp *repository.Rep
 	for {
 		states, _, err := gh.Repositories.ListStatuses(ctx, owner, repo, rsp.Sha, &github.ListOptions{Page: i, PerPage: 200})
 		if err != nil {
-			return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+			return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 		}
 
 		if len(states) == 0 {
@@ -182,7 +182,7 @@ func (rs *RepositoryServer) ClearStates(ctx context.Context, rsp *repository.Rep
 		status.Description = github.String("The run that this test was a part of has been overridden by a new run. Pushing a new change will remove this error.")
 		_, _, err := gh.Repositories.CreateStatus(ctx, owner, repo, rsp.Sha, status)
 		if err != nil {
-			return nil, errors.New(err).ToGRPC(codes.FailedPrecondition)
+			return nil, errors.New(err).(errors.Error).ToGRPC(codes.FailedPrecondition)
 		}
 	}
 

--- a/api/repository/github/user.go
+++ b/api/repository/github/user.go
@@ -19,7 +19,7 @@ func (rs *RepositoryServer) MyLogin(ctx context.Context, token *repository.Strin
 
 	u, _, err := gh.Users.Get(ctx, "")
 	if err != nil {
-		return nil, errors.New(err).Wrap("trying to get login username for token").ToGRPC(codes.FailedPrecondition)
+		return nil, errors.New(err).(errors.Error).Wrap("trying to get login username for token").ToGRPC(codes.FailedPrecondition)
 	}
 
 	return &repository.String{Name: u.GetLogin()}, nil

--- a/api/uisvc/cmd/uisvc-server/main.go
+++ b/api/uisvc/cmd/uisvc-server/main.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/tinyci/ci-agents/config"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 	"github.com/urfave/cli"
 
@@ -36,9 +35,6 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		if e, ok := err.(*errors.Error); ok && e == nil {
-			return
-		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/api/uisvc/restapi/capability.go
+++ b/api/uisvc/restapi/capability.go
@@ -4,13 +4,12 @@ import (
 	"context"
 
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 	"github.com/tinyci/ci-agents/model"
 )
 
 // AddCapability adds a capability for a user.
-func AddCapability(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func AddCapability(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	u, err := h.Clients.Data.GetUser(pCtx, ctx.GetString("username"))
 	if err != nil {
 		return nil, 500, err
@@ -20,7 +19,7 @@ func AddCapability(pCtx context.Context, h *handlers.H, ctx *gin.Context) (inter
 }
 
 // RemoveCapability removes a capability from a user.
-func RemoveCapability(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func RemoveCapability(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	u, err := h.Clients.Data.GetUser(pCtx, ctx.GetString("username"))
 	if err != nil {
 		return nil, 500, err

--- a/api/uisvc/restapi/configure_uisvc.go
+++ b/api/uisvc/restapi/configure_uisvc.go
@@ -18,7 +18,7 @@ func MakeHandlerConfig(sc config.ServiceConfig) *HandlerConfig {
 }
 
 // Validate allows you to perform your own custom validations on the configuration.
-func (hc HandlerConfig) Validate(h *handlers.H) *errors.Error {
+func (hc HandlerConfig) Validate(h *handlers.H) error {
 	if h.ClientConfig.Data == "" {
 		return errors.New("no datasvc url specified")
 	}
@@ -35,7 +35,7 @@ func (hc HandlerConfig) Validate(h *handlers.H) *errors.Error {
 }
 
 // CustomInit allows you to perform any final magic before boot.
-func (hc HandlerConfig) CustomInit(h *handlers.H) *errors.Error {
+func (hc HandlerConfig) CustomInit(h *handlers.H) error {
 	h.NoTLSServer = true
 	h.UseSessions = true
 	h.Port = 6010
@@ -45,13 +45,13 @@ func (hc HandlerConfig) CustomInit(h *handlers.H) *errors.Error {
 }
 
 // DBConfigure configures the database if necessary.
-func (hc HandlerConfig) DBConfigure(h *handlers.H) *errors.Error {
+func (hc HandlerConfig) DBConfigure(h *handlers.H) error {
 	return nil
 }
 
 // Configure allows you to configure the routes, in particular. Setting the
 // processing functions here will be a big part of your day job.
-func (hc HandlerConfig) Configure(router handlers.Routes) *errors.Error {
+func (hc HandlerConfig) Configure(router handlers.Routes) error {
 	router.SetProcessor("/errors", "get", Errors)
 	router.SetProcessor("/login", "get", Login)
 	router.SetProcessor("/login/upgrade", "get", Upgrade)

--- a/api/uisvc/restapi/errors.go
+++ b/api/uisvc/restapi/errors.go
@@ -9,19 +9,19 @@ import (
 )
 
 // Errors processes the /errors GET endpoint
-func Errors(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func Errors(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	user, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err
 	}
 
 	errs, err := h.Clients.Data.GetErrors(ctx, user.Username)
-	if err != nil && !err.Contains(errors.New("record not found")) {
+	if err != nil && !err.(errors.Error).Contains(errors.New("record not found")) {
 		return nil, 500, err
 	}
 
 	for _, err := range errs {
-		if err := h.Clients.Data.DeleteError(pCtx, err.ID, user.ID); err != nil && !err.Contains(errors.New("record not found")) {
+		if err := h.Clients.Data.DeleteError(pCtx, err.ID, user.ID); err != nil && !err.(errors.Error).Contains(errors.New("record not found")) {
 			return nil, 500, err
 		}
 	}

--- a/api/uisvc/restapi/log.go
+++ b/api/uisvc/restapi/log.go
@@ -12,7 +12,7 @@ import (
 )
 
 // LogAttach connects to a running logging process and outputs the return data as it arrives.
-func LogAttach(pCtx context.Context, h *handlers.H, ctx *gin.Context, conn *websocket.Conn) *errors.Error {
+func LogAttach(pCtx context.Context, h *handlers.H, ctx *gin.Context, conn *websocket.Conn) error {
 	id, err := strconv.ParseInt(ctx.GetString("id"), 10, 64)
 	if err != nil {
 		return errors.New(err)

--- a/api/uisvc/restapi/operations/delete_capabilities_username_capability.go
+++ b/api/uisvc/restapi/operations/delete_capabilities_username_capability.go
@@ -21,14 +21,14 @@ import (
 // DeleteCapabilitiesUsernameCapability swagger:route DELETE /capabilities/{username}/{capability} deleteCapabilitiesUsernameCapability
 // Remove a named capability
 // Remove a named capability from a provided user ID. Requires the user have the 'modify:user' capability.
-func DeleteCapabilitiesUsernameCapability(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func DeleteCapabilitiesUsernameCapability(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/delete_capabilities_username_capability_parameters.go
+++ b/api/uisvc/restapi/operations/delete_capabilities_username_capability_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // DeleteCapabilitiesUsernameCapabilityValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func DeleteCapabilitiesUsernameCapabilityValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func DeleteCapabilitiesUsernameCapabilityValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	capability := ctx.Param("capability")
 
 	if len(capability) == 0 {

--- a/api/uisvc/restapi/operations/delete_capabilities_username_capability_responses.go
+++ b/api/uisvc/restapi/operations/delete_capabilities_username_capability_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // DeleteCapabilitiesUsernameCapabilityResponse responds for DeleteCapabilitiesUsernameCapability.
-func DeleteCapabilitiesUsernameCapabilityResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func DeleteCapabilitiesUsernameCapabilityResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/delete_token.go
+++ b/api/uisvc/restapi/operations/delete_token.go
@@ -22,14 +22,14 @@ import (
 // Remove and reset your tinyCI access token
 // The next GET /token will create a new one. This will just remove it.
 //
-func DeleteToken(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func DeleteToken(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/delete_token_parameters.go
+++ b/api/uisvc/restapi/operations/delete_token_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // DeleteTokenValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func DeleteTokenValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func DeleteTokenValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 
 	return nil
 }

--- a/api/uisvc/restapi/operations/delete_token_responses.go
+++ b/api/uisvc/restapi/operations/delete_token_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // DeleteTokenResponse responds for DeleteToken.
-func DeleteTokenResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func DeleteTokenResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_errors.go
+++ b/api/uisvc/restapi/operations/get_errors.go
@@ -21,14 +21,14 @@ import (
 // GetErrors swagger:route GET /errors getErrors
 // Retrieve errors
 // Server retrieves any errors the last call(s) have set for you.
-func GetErrors(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetErrors(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_errors_parameters.go
+++ b/api/uisvc/restapi/operations/get_errors_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetErrorsValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetErrorsValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetErrorsValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 
 	return nil
 }

--- a/api/uisvc/restapi/operations/get_errors_responses.go
+++ b/api/uisvc/restapi/operations/get_errors_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetErrorsResponse responds for GetErrors.
-func GetErrorsResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetErrorsResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_log_attach_id.go
+++ b/api/uisvc/restapi/operations/get_log_attach_id.go
@@ -22,14 +22,14 @@ import (
 // Attach to a running log
 // For a given ID, find the log and if it is running, attach to it and start receiving the latest content from it.
 //
-func GetLogAttachID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetLogAttachID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_log_attach_id_parameters.go
+++ b/api/uisvc/restapi/operations/get_log_attach_id_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetLogAttachIDValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetLogAttachIDValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetLogAttachIDValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	id := ctx.Param("id")
 
 	if len(id) == 0 {

--- a/api/uisvc/restapi/operations/get_log_attach_id_responses.go
+++ b/api/uisvc/restapi/operations/get_log_attach_id_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetLogAttachIDResponse responds for GetLogAttachID.
-func GetLogAttachIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetLogAttachIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_loggedin.go
+++ b/api/uisvc/restapi/operations/get_loggedin.go
@@ -23,14 +23,14 @@ import (
 // Validate the logged-in status of the user. Validates the session cookie against the internal database.
 // If the user is logged in, a JSON string of "true" will be sent; otherwise an oauth redirect url will be passed for calling out to by the client.
 //
-func GetLoggedin(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetLoggedin(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_loggedin_parameters.go
+++ b/api/uisvc/restapi/operations/get_loggedin_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetLoggedinValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetLoggedinValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetLoggedinValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 
 	return nil
 }

--- a/api/uisvc/restapi/operations/get_loggedin_responses.go
+++ b/api/uisvc/restapi/operations/get_loggedin_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetLoggedinResponse responds for GetLoggedin.
-func GetLoggedinResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetLoggedinResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_login.go
+++ b/api/uisvc/restapi/operations/get_login.go
@@ -22,14 +22,14 @@ import (
 // Log into the system
 // Handle the server side of the oauth challenge. It is important to preserve the cookie jar after this call is made, as session cookies are used to manage many of the calls in this API.
 //
-func GetLogin(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetLogin(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_login_parameters.go
+++ b/api/uisvc/restapi/operations/get_login_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetLoginValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetLoginValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetLoginValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	code := ctx.Query("code")
 
 	if len(code) == 0 {

--- a/api/uisvc/restapi/operations/get_login_responses.go
+++ b/api/uisvc/restapi/operations/get_login_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetLoginResponse responds for GetLogin.
-func GetLoginResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetLoginResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_login_upgrade.go
+++ b/api/uisvc/restapi/operations/get_login_upgrade.go
@@ -22,14 +22,14 @@ import (
 // Log into the system with upgraded permissions
 // This upgrades the permissions of the user (which requires confirmation from the OAuthing site) to allow repository access, so that additional permission to manipulate repositories and scan additional ones is available.
 //
-func GetLoginUpgrade(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetLoginUpgrade(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_login_upgrade_parameters.go
+++ b/api/uisvc/restapi/operations/get_login_upgrade_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetLoginUpgradeValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetLoginUpgradeValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetLoginUpgradeValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 
 	return nil
 }

--- a/api/uisvc/restapi/operations/get_login_upgrade_responses.go
+++ b/api/uisvc/restapi/operations/get_login_upgrade_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetLoginUpgradeResponse responds for GetLoginUpgrade.
-func GetLoginUpgradeResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetLoginUpgradeResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_logout.go
+++ b/api/uisvc/restapi/operations/get_logout.go
@@ -22,14 +22,14 @@ import (
 // Log out of the system
 // Conveniently clears session cookies. You will need to login again. Does not clear oauth tokens.
 //
-func GetLogout(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetLogout(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_logout_parameters.go
+++ b/api/uisvc/restapi/operations/get_logout_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetLogoutValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetLogoutValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetLogoutValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 
 	return nil
 }

--- a/api/uisvc/restapi/operations/get_logout_responses.go
+++ b/api/uisvc/restapi/operations/get_logout_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetLogoutResponse responds for GetLogout.
-func GetLogoutResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetLogoutResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_repositories_ci_add_owner_repo.go
+++ b/api/uisvc/restapi/operations/get_repositories_ci_add_owner_repo.go
@@ -22,14 +22,14 @@ import (
 // Add a specific repository to CI.
 // Generates a hook secret and populates the user's repository with it and the hook URL. Returns 200 on success, 500 + error message on failure, or if the repository has already been added to CI.
 //
-func GetRepositoriesCiAddOwnerRepo(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRepositoriesCiAddOwnerRepo(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_repositories_ci_add_owner_repo_parameters.go
+++ b/api/uisvc/restapi/operations/get_repositories_ci_add_owner_repo_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetRepositoriesCiAddOwnerRepoValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRepositoriesCiAddOwnerRepoValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRepositoriesCiAddOwnerRepoValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	owner := ctx.Param("owner")
 
 	if len(owner) == 0 {

--- a/api/uisvc/restapi/operations/get_repositories_ci_add_owner_repo_responses.go
+++ b/api/uisvc/restapi/operations/get_repositories_ci_add_owner_repo_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRepositoriesCiAddOwnerRepoResponse responds for GetRepositoriesCiAddOwnerRepo.
-func GetRepositoriesCiAddOwnerRepoResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRepositoriesCiAddOwnerRepoResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_repositories_ci_del_owner_repo.go
+++ b/api/uisvc/restapi/operations/get_repositories_ci_del_owner_repo.go
@@ -22,14 +22,14 @@ import (
 // Removes a specific repository from CI.
 // Will fail if not added to CI already; does not currently clear the hook.
 //
-func GetRepositoriesCiDelOwnerRepo(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRepositoriesCiDelOwnerRepo(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_repositories_ci_del_owner_repo_parameters.go
+++ b/api/uisvc/restapi/operations/get_repositories_ci_del_owner_repo_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetRepositoriesCiDelOwnerRepoValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRepositoriesCiDelOwnerRepoValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRepositoriesCiDelOwnerRepoValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	owner := ctx.Param("owner")
 
 	if len(owner) == 0 {

--- a/api/uisvc/restapi/operations/get_repositories_ci_del_owner_repo_responses.go
+++ b/api/uisvc/restapi/operations/get_repositories_ci_del_owner_repo_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRepositoriesCiDelOwnerRepoResponse responds for GetRepositoriesCiDelOwnerRepo.
-func GetRepositoriesCiDelOwnerRepoResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRepositoriesCiDelOwnerRepoResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_repositories_my.go
+++ b/api/uisvc/restapi/operations/get_repositories_my.go
@@ -21,14 +21,14 @@ import (
 // GetRepositoriesMy swagger:route GET /repositories/my getRepositoriesMy
 // Fetch all the writable repositories for the user.
 // Returns a types.RepositoryList for all the repos a user has write access to.
-func GetRepositoriesMy(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRepositoriesMy(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_repositories_my_parameters.go
+++ b/api/uisvc/restapi/operations/get_repositories_my_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetRepositoriesMyValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRepositoriesMyValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRepositoriesMyValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	search := ctx.Query("search")
 
 	ctx.Set("search", search)

--- a/api/uisvc/restapi/operations/get_repositories_my_responses.go
+++ b/api/uisvc/restapi/operations/get_repositories_my_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRepositoriesMyResponse responds for GetRepositoriesMy.
-func GetRepositoriesMyResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRepositoriesMyResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_repositories_scan.go
+++ b/api/uisvc/restapi/operations/get_repositories_scan.go
@@ -21,14 +21,14 @@ import (
 // GetRepositoriesScan swagger:route GET /repositories/scan getRepositoriesScan
 // Scan repositories from the remote resource
 // Reads the repositories list from the API resource, e.g., Github.
-func GetRepositoriesScan(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRepositoriesScan(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_repositories_scan_parameters.go
+++ b/api/uisvc/restapi/operations/get_repositories_scan_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetRepositoriesScanValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRepositoriesScanValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRepositoriesScanValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 
 	return nil
 }

--- a/api/uisvc/restapi/operations/get_repositories_scan_responses.go
+++ b/api/uisvc/restapi/operations/get_repositories_scan_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRepositoriesScanResponse responds for GetRepositoriesScan.
-func GetRepositoriesScanResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRepositoriesScanResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_repositories_sub_add_owner_repo.go
+++ b/api/uisvc/restapi/operations/get_repositories_sub_add_owner_repo.go
@@ -22,14 +22,14 @@ import (
 // Subscribe to a repository running CI
 // Subscribing makes that repo's queue items appear in your home view. Returns 200 on success, 500 + error on failure.
 //
-func GetRepositoriesSubAddOwnerRepo(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRepositoriesSubAddOwnerRepo(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_repositories_sub_add_owner_repo_parameters.go
+++ b/api/uisvc/restapi/operations/get_repositories_sub_add_owner_repo_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetRepositoriesSubAddOwnerRepoValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRepositoriesSubAddOwnerRepoValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRepositoriesSubAddOwnerRepoValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	owner := ctx.Param("owner")
 
 	if len(owner) == 0 {

--- a/api/uisvc/restapi/operations/get_repositories_sub_add_owner_repo_responses.go
+++ b/api/uisvc/restapi/operations/get_repositories_sub_add_owner_repo_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRepositoriesSubAddOwnerRepoResponse responds for GetRepositoriesSubAddOwnerRepo.
-func GetRepositoriesSubAddOwnerRepoResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRepositoriesSubAddOwnerRepoResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_repositories_sub_del_owner_repo.go
+++ b/api/uisvc/restapi/operations/get_repositories_sub_del_owner_repo.go
@@ -22,14 +22,14 @@ import (
 // Unsubscribe from a repository
 // Unsubscribing removes any existing subscription. Either way, if nothing broke, it returns 200. Otherwise it returns 500 and the error.
 //
-func GetRepositoriesSubDelOwnerRepo(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRepositoriesSubDelOwnerRepo(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_repositories_sub_del_owner_repo_parameters.go
+++ b/api/uisvc/restapi/operations/get_repositories_sub_del_owner_repo_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetRepositoriesSubDelOwnerRepoValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRepositoriesSubDelOwnerRepoValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRepositoriesSubDelOwnerRepoValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	owner := ctx.Param("owner")
 
 	if len(owner) == 0 {

--- a/api/uisvc/restapi/operations/get_repositories_sub_del_owner_repo_responses.go
+++ b/api/uisvc/restapi/operations/get_repositories_sub_del_owner_repo_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRepositoriesSubDelOwnerRepoResponse responds for GetRepositoriesSubDelOwnerRepo.
-func GetRepositoriesSubDelOwnerRepoResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRepositoriesSubDelOwnerRepoResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_repositories_subscribed.go
+++ b/api/uisvc/restapi/operations/get_repositories_subscribed.go
@@ -21,14 +21,14 @@ import (
 // GetRepositoriesSubscribed swagger:route GET /repositories/subscribed getRepositoriesSubscribed
 // List all subscribed repositories
 // Returns a types.RepositoryList of all the repos the user is subscribed to.
-func GetRepositoriesSubscribed(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRepositoriesSubscribed(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_repositories_subscribed_parameters.go
+++ b/api/uisvc/restapi/operations/get_repositories_subscribed_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetRepositoriesSubscribedValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRepositoriesSubscribedValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRepositoriesSubscribedValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	search := ctx.Query("search")
 
 	ctx.Set("search", search)

--- a/api/uisvc/restapi/operations/get_repositories_subscribed_responses.go
+++ b/api/uisvc/restapi/operations/get_repositories_subscribed_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRepositoriesSubscribedResponse responds for GetRepositoriesSubscribed.
-func GetRepositoriesSubscribedResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRepositoriesSubscribedResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_repositories_visible.go
+++ b/api/uisvc/restapi/operations/get_repositories_visible.go
@@ -21,14 +21,14 @@ import (
 // GetRepositoriesVisible swagger:route GET /repositories/visible getRepositoriesVisible
 // Fetch all the repositories the user can view.
 // Returns a types.RepositoryList for all the repos a user has view access to.
-func GetRepositoriesVisible(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRepositoriesVisible(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_repositories_visible_parameters.go
+++ b/api/uisvc/restapi/operations/get_repositories_visible_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetRepositoriesVisibleValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRepositoriesVisibleValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRepositoriesVisibleValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	search := ctx.Query("search")
 
 	ctx.Set("search", search)

--- a/api/uisvc/restapi/operations/get_repositories_visible_responses.go
+++ b/api/uisvc/restapi/operations/get_repositories_visible_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRepositoriesVisibleResponse responds for GetRepositoriesVisible.
-func GetRepositoriesVisibleResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRepositoriesVisibleResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_run_run_id.go
+++ b/api/uisvc/restapi/operations/get_run_run_id.go
@@ -21,14 +21,14 @@ import (
 // GetRunRunID swagger:route GET /run/{run_id} getRunRunId
 // Get a run by ID
 // Retrieve a Run by ID; this will return the full Run object including all relationships.
-func GetRunRunID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRunRunID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_run_run_id_parameters.go
+++ b/api/uisvc/restapi/operations/get_run_run_id_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetRunRunIDValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRunRunIDValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRunRunIDValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	runID := ctx.Param("run_id")
 
 	if len(runID) == 0 {

--- a/api/uisvc/restapi/operations/get_run_run_id_responses.go
+++ b/api/uisvc/restapi/operations/get_run_run_id_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRunRunIDResponse responds for GetRunRunID.
-func GetRunRunIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRunRunIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_runs.go
+++ b/api/uisvc/restapi/operations/get_runs.go
@@ -22,14 +22,14 @@ import (
 // Obtain the run list for the user
 // List all the runs, optionally filtering by repository or repository+SHA. Pagination controls are available.
 //
-func GetRuns(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRuns(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_runs_count.go
+++ b/api/uisvc/restapi/operations/get_runs_count.go
@@ -22,14 +22,14 @@ import (
 // Count the runs
 // Count the runs, optionally filtering by repository or repository+SHA.
 //
-func GetRunsCount(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetRunsCount(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_runs_count_parameters.go
+++ b/api/uisvc/restapi/operations/get_runs_count_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetRunsCountValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRunsCountValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRunsCountValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	repository := ctx.Query("repository")
 
 	ctx.Set("repository", repository)

--- a/api/uisvc/restapi/operations/get_runs_count_responses.go
+++ b/api/uisvc/restapi/operations/get_runs_count_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRunsCountResponse responds for GetRunsCount.
-func GetRunsCountResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRunsCountResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_runs_parameters.go
+++ b/api/uisvc/restapi/operations/get_runs_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetRunsValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetRunsValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetRunsValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	page := ctx.Query("page")
 
 	if len(page) == 0 {

--- a/api/uisvc/restapi/operations/get_runs_responses.go
+++ b/api/uisvc/restapi/operations/get_runs_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetRunsResponse responds for GetRuns.
-func GetRunsResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetRunsResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_submission_id.go
+++ b/api/uisvc/restapi/operations/get_submission_id.go
@@ -21,14 +21,14 @@ import (
 // GetSubmissionID swagger:route GET /submission/{id} getSubmissionId
 // Get a submission by ID
 // Retrieve a Submission by ID; this will return the full Submission object including all relationships.
-func GetSubmissionID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetSubmissionID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_submission_id_parameters.go
+++ b/api/uisvc/restapi/operations/get_submission_id_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetSubmissionIDValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetSubmissionIDValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetSubmissionIDValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	id := ctx.Param("id")
 
 	if len(id) == 0 {

--- a/api/uisvc/restapi/operations/get_submission_id_responses.go
+++ b/api/uisvc/restapi/operations/get_submission_id_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetSubmissionIDResponse responds for GetSubmissionID.
-func GetSubmissionIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetSubmissionIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_submission_id_runs.go
+++ b/api/uisvc/restapi/operations/get_submission_id_runs.go
@@ -21,14 +21,14 @@ import (
 // GetSubmissionIDRuns swagger:route GET /submission/{id}/runs getSubmissionIdRuns
 // Get submission runs by ID
 // Retrieve a Submission's runs by ID; this will return the list of runs with pagination.
-func GetSubmissionIDRuns(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetSubmissionIDRuns(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_submission_id_runs_parameters.go
+++ b/api/uisvc/restapi/operations/get_submission_id_runs_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetSubmissionIDRunsValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetSubmissionIDRunsValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetSubmissionIDRunsValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	id := ctx.Param("id")
 
 	if len(id) == 0 {

--- a/api/uisvc/restapi/operations/get_submission_id_runs_responses.go
+++ b/api/uisvc/restapi/operations/get_submission_id_runs_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetSubmissionIDRunsResponse responds for GetSubmissionIDRuns.
-func GetSubmissionIDRunsResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetSubmissionIDRunsResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_submission_id_tasks.go
+++ b/api/uisvc/restapi/operations/get_submission_id_tasks.go
@@ -21,14 +21,14 @@ import (
 // GetSubmissionIDTasks swagger:route GET /submission/{id}/tasks getSubmissionIdTasks
 // Get submission tasks by ID
 // Retrieve a Submission's tasks by ID; this will return the list of tasks with pagination.
-func GetSubmissionIDTasks(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetSubmissionIDTasks(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_submission_id_tasks_parameters.go
+++ b/api/uisvc/restapi/operations/get_submission_id_tasks_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetSubmissionIDTasksValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetSubmissionIDTasksValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetSubmissionIDTasksValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	id := ctx.Param("id")
 
 	if len(id) == 0 {

--- a/api/uisvc/restapi/operations/get_submission_id_tasks_responses.go
+++ b/api/uisvc/restapi/operations/get_submission_id_tasks_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetSubmissionIDTasksResponse responds for GetSubmissionIDTasks.
-func GetSubmissionIDTasksResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetSubmissionIDTasksResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_submissions.go
+++ b/api/uisvc/restapi/operations/get_submissions.go
@@ -21,14 +21,14 @@ import (
 // GetSubmissions swagger:route GET /submissions getSubmissions
 // List submisssions
 // Retrieve a list of Submissions; this will return the full Submission object including all relationships.
-func GetSubmissions(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetSubmissions(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_submissions_count.go
+++ b/api/uisvc/restapi/operations/get_submissions_count.go
@@ -21,14 +21,14 @@ import (
 // GetSubmissionsCount swagger:route GET /submissions/count getSubmissionsCount
 // Count submisssions
 // Retrieve a count of Submissions that match the filter.
-func GetSubmissionsCount(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetSubmissionsCount(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_submissions_count_parameters.go
+++ b/api/uisvc/restapi/operations/get_submissions_count_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetSubmissionsCountValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetSubmissionsCountValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetSubmissionsCountValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	repository := ctx.Query("repository")
 
 	ctx.Set("repository", repository)

--- a/api/uisvc/restapi/operations/get_submissions_count_responses.go
+++ b/api/uisvc/restapi/operations/get_submissions_count_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetSubmissionsCountResponse responds for GetSubmissionsCount.
-func GetSubmissionsCountResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetSubmissionsCountResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_submissions_parameters.go
+++ b/api/uisvc/restapi/operations/get_submissions_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetSubmissionsValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetSubmissionsValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetSubmissionsValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	page := ctx.Query("page")
 
 	if len(page) == 0 {

--- a/api/uisvc/restapi/operations/get_submissions_responses.go
+++ b/api/uisvc/restapi/operations/get_submissions_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetSubmissionsResponse responds for GetSubmissions.
-func GetSubmissionsResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetSubmissionsResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_submit.go
+++ b/api/uisvc/restapi/operations/get_submit.go
@@ -22,14 +22,14 @@ import (
 // Perform a manual submission to tinyCI
 // This allows a user to push a job instead of pushing to git or filing a pull request to trigger a job. It is available on the tinyCI UI and CLI client.
 //
-func GetSubmit(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetSubmit(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_submit_parameters.go
+++ b/api/uisvc/restapi/operations/get_submit_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetSubmitValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetSubmitValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetSubmitValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	all := ctx.Query("all")
 
 	ctx.Set("all", all)

--- a/api/uisvc/restapi/operations/get_submit_responses.go
+++ b/api/uisvc/restapi/operations/get_submit_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetSubmitResponse responds for GetSubmit.
-func GetSubmitResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetSubmitResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_tasks.go
+++ b/api/uisvc/restapi/operations/get_tasks.go
@@ -22,14 +22,14 @@ import (
 // Obtain the task list optionally filtering by repository and sha.
 // The tasks list returns a list of Task objects that correspond to the query. Each query may contain pagination or filtering rules to limit its contents. It is strongly recommended to look at the "count" equivalents for these endpoints so that you can implement pagination more simply.
 //
-func GetTasks(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetTasks(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_tasks_count.go
+++ b/api/uisvc/restapi/operations/get_tasks_count.go
@@ -22,14 +22,14 @@ import (
 // Count the Tasks
 // Perform a full count of tasks that meet the filter criteria (which can be no filter) and return it as integer.
 //
-func GetTasksCount(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetTasksCount(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_tasks_count_parameters.go
+++ b/api/uisvc/restapi/operations/get_tasks_count_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetTasksCountValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetTasksCountValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetTasksCountValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	repository := ctx.Query("repository")
 
 	ctx.Set("repository", repository)

--- a/api/uisvc/restapi/operations/get_tasks_count_responses.go
+++ b/api/uisvc/restapi/operations/get_tasks_count_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetTasksCountResponse responds for GetTasksCount.
-func GetTasksCountResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetTasksCountResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_tasks_parameters.go
+++ b/api/uisvc/restapi/operations/get_tasks_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetTasksValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetTasksValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetTasksValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	page := ctx.Query("page")
 
 	if len(page) == 0 {

--- a/api/uisvc/restapi/operations/get_tasks_responses.go
+++ b/api/uisvc/restapi/operations/get_tasks_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetTasksResponse responds for GetTasks.
-func GetTasksResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetTasksResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_tasks_runs_id.go
+++ b/api/uisvc/restapi/operations/get_tasks_runs_id.go
@@ -22,14 +22,14 @@ import (
 // Obtain the run list based on the task ID.
 // The queue list only contains: * stuff * other junk
 //
-func GetTasksRunsID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetTasksRunsID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_tasks_runs_id_count.go
+++ b/api/uisvc/restapi/operations/get_tasks_runs_id_count.go
@@ -22,14 +22,14 @@ import (
 // Count the runs corresponding to the task ID.
 // Get the count of runs that correspond to the task ID. Returns an integer.
 //
-func GetTasksRunsIDCount(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetTasksRunsIDCount(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_tasks_runs_id_count_parameters.go
+++ b/api/uisvc/restapi/operations/get_tasks_runs_id_count_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetTasksRunsIDCountValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetTasksRunsIDCountValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetTasksRunsIDCountValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	id := ctx.Param("id")
 
 	if len(id) == 0 {

--- a/api/uisvc/restapi/operations/get_tasks_runs_id_count_responses.go
+++ b/api/uisvc/restapi/operations/get_tasks_runs_id_count_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetTasksRunsIDCountResponse responds for GetTasksRunsIDCount.
-func GetTasksRunsIDCountResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetTasksRunsIDCountResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_tasks_runs_id_parameters.go
+++ b/api/uisvc/restapi/operations/get_tasks_runs_id_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // GetTasksRunsIDValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetTasksRunsIDValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetTasksRunsIDValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	id := ctx.Param("id")
 
 	if len(id) == 0 {

--- a/api/uisvc/restapi/operations/get_tasks_runs_id_responses.go
+++ b/api/uisvc/restapi/operations/get_tasks_runs_id_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetTasksRunsIDResponse responds for GetTasksRunsID.
-func GetTasksRunsIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetTasksRunsIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_tasks_subscribed.go
+++ b/api/uisvc/restapi/operations/get_tasks_subscribed.go
@@ -22,14 +22,14 @@ import (
 // Obtain the list of tasks that belong to repositories you are subscribed to.
 // This call implements basic pagination over the entire task corpus that intersects with your subscription list. It returns a list of tasks.
 //
-func GetTasksSubscribed(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetTasksSubscribed(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_tasks_subscribed_parameters.go
+++ b/api/uisvc/restapi/operations/get_tasks_subscribed_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetTasksSubscribedValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetTasksSubscribedValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetTasksSubscribedValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	page := ctx.Query("page")
 
 	if len(page) == 0 {

--- a/api/uisvc/restapi/operations/get_tasks_subscribed_responses.go
+++ b/api/uisvc/restapi/operations/get_tasks_subscribed_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetTasksSubscribedResponse responds for GetTasksSubscribed.
-func GetTasksSubscribedResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetTasksSubscribedResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_token.go
+++ b/api/uisvc/restapi/operations/get_token.go
@@ -22,14 +22,14 @@ import (
 // Get a tinyCI access token
 // This will allow you unfettered access to the system as your user that you request the token with.
 //
-func GetToken(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetToken(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_token_parameters.go
+++ b/api/uisvc/restapi/operations/get_token_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetTokenValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetTokenValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetTokenValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 
 	return nil
 }

--- a/api/uisvc/restapi/operations/get_token_responses.go
+++ b/api/uisvc/restapi/operations/get_token_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetTokenResponse responds for GetToken.
-func GetTokenResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetTokenResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/get_user_properties.go
+++ b/api/uisvc/restapi/operations/get_user_properties.go
@@ -22,14 +22,14 @@ import (
 // Get information about the current user
 // Get information about the current user, such as the username.
 //
-func GetUserProperties(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func GetUserProperties(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/get_user_properties_parameters.go
+++ b/api/uisvc/restapi/operations/get_user_properties_parameters.go
@@ -2,13 +2,12 @@ package operations
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetUserPropertiesValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func GetUserPropertiesValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func GetUserPropertiesValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 
 	return nil
 }

--- a/api/uisvc/restapi/operations/get_user_properties_responses.go
+++ b/api/uisvc/restapi/operations/get_user_properties_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // GetUserPropertiesResponse responds for GetUserProperties.
-func GetUserPropertiesResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func GetUserPropertiesResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/post_cancel_run_id.go
+++ b/api/uisvc/restapi/operations/post_cancel_run_id.go
@@ -23,14 +23,14 @@ import (
 // Cancel the run by ID; this will actually trickle back and cancel the whole task, since it can no longer succeed in any way.
 // Please keep in mind to stop runs, runners must implement a cancel poller.
 //
-func PostCancelRunID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func PostCancelRunID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/post_cancel_run_id_parameters.go
+++ b/api/uisvc/restapi/operations/post_cancel_run_id_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // PostCancelRunIDValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func PostCancelRunIDValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func PostCancelRunIDValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	runID := ctx.Param("run_id")
 
 	if len(runID) == 0 {

--- a/api/uisvc/restapi/operations/post_cancel_run_id_responses.go
+++ b/api/uisvc/restapi/operations/post_cancel_run_id_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // PostCancelRunIDResponse responds for PostCancelRunID.
-func PostCancelRunIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func PostCancelRunIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/post_capabilities_username_capability.go
+++ b/api/uisvc/restapi/operations/post_capabilities_username_capability.go
@@ -21,14 +21,14 @@ import (
 // PostCapabilitiesUsernameCapability swagger:route POST /capabilities/{username}/{capability} postCapabilitiesUsernameCapability
 // Add a named capability
 // Add a named capability for a provided user ID. Requires the user have the 'modify:user' capability.
-func PostCapabilitiesUsernameCapability(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func PostCapabilitiesUsernameCapability(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/post_capabilities_username_capability_parameters.go
+++ b/api/uisvc/restapi/operations/post_capabilities_username_capability_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // PostCapabilitiesUsernameCapabilityValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func PostCapabilitiesUsernameCapabilityValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func PostCapabilitiesUsernameCapabilityValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	capability := ctx.Param("capability")
 
 	if len(capability) == 0 {

--- a/api/uisvc/restapi/operations/post_capabilities_username_capability_responses.go
+++ b/api/uisvc/restapi/operations/post_capabilities_username_capability_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // PostCapabilitiesUsernameCapabilityResponse responds for PostCapabilitiesUsernameCapability.
-func PostCapabilitiesUsernameCapabilityResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func PostCapabilitiesUsernameCapabilityResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/post_submission_id_cancel.go
+++ b/api/uisvc/restapi/operations/post_submission_id_cancel.go
@@ -21,14 +21,14 @@ import (
 // PostSubmissionIDCancel swagger:route POST /submission/{id}/cancel postSubmissionIdCancel
 // Cancel a submission by ID
 // Cancel a Submission by ID; this will cancel all sub-tasks and their runs.
-func PostSubmissionIDCancel(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func PostSubmissionIDCancel(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/post_submission_id_cancel_parameters.go
+++ b/api/uisvc/restapi/operations/post_submission_id_cancel_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // PostSubmissionIDCancelValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func PostSubmissionIDCancelValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func PostSubmissionIDCancelValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	id := ctx.Param("id")
 
 	if len(id) == 0 {

--- a/api/uisvc/restapi/operations/post_submission_id_cancel_responses.go
+++ b/api/uisvc/restapi/operations/post_submission_id_cancel_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // PostSubmissionIDCancelResponse responds for PostSubmissionIDCancel.
-func PostSubmissionIDCancelResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func PostSubmissionIDCancelResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/operations/post_tasks_cancel_id.go
+++ b/api/uisvc/restapi/operations/post_tasks_cancel_id.go
@@ -22,14 +22,14 @@ import (
 // Cancel by Task ID
 // Cancel the runs for a task by ID
 //
-func PostTasksCancelID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func PostTasksCancelID(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
 	if h.RequestLogging {
 		start := time.Now()
 		u := uuid.New()
 
 		content, jsonErr := json.Marshal(ctx.Params)
 		if jsonErr != nil {
-			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+			h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
 		}
 
 		logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/api/uisvc/restapi/operations/post_tasks_cancel_id_parameters.go
+++ b/api/uisvc/restapi/operations/post_tasks_cancel_id_parameters.go
@@ -8,7 +8,7 @@ import (
 
 // PostTasksCancelIDValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func PostTasksCancelIDValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func PostTasksCancelIDValidateURLParams(h *handlers.H, ctx *gin.Context) error {
 	id := ctx.Param("id")
 
 	if len(id) == 0 {

--- a/api/uisvc/restapi/operations/post_tasks_cancel_id_responses.go
+++ b/api/uisvc/restapi/operations/post_tasks_cancel_id_responses.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +10,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // PostTasksCancelIDResponse responds for PostTasksCancelID.
-func PostTasksCancelIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func PostTasksCancelIDResponse(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
 	if err != nil {
 		h.LogError(err, ctx, code)
 		return err

--- a/api/uisvc/restapi/repository.go
+++ b/api/uisvc/restapi/repository.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ListRepositoriesSubscribed lists all subscribed repos as JSON.
-func ListRepositoriesSubscribed(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func ListRepositoriesSubscribed(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	user, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err
@@ -23,7 +23,7 @@ func ListRepositoriesSubscribed(pCtx context.Context, h *handlers.H, ctx *gin.Co
 }
 
 // ScanRepositories scans for owned and managed repositories for Add-to-CI operations.
-func ScanRepositories(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func ScanRepositories(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	user, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err
@@ -58,7 +58,7 @@ func ScanRepositories(pCtx context.Context, h *handlers.H, ctx *gin.Context) (in
 }
 
 // ListRepositoriesMy lists the repositories the user can modify.
-func ListRepositoriesMy(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func ListRepositoriesMy(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	user, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err
@@ -73,7 +73,7 @@ func ListRepositoriesMy(pCtx context.Context, h *handlers.H, ctx *gin.Context) (
 }
 
 // ListRepositoriesVisible returns all the repos the user can see.
-func ListRepositoriesVisible(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func ListRepositoriesVisible(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	user, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err
@@ -84,7 +84,7 @@ func ListRepositoriesVisible(pCtx context.Context, h *handlers.H, ctx *gin.Conte
 }
 
 // DeleteRepositoryFromCI removes the repository from CI. that's it.
-func DeleteRepositoryFromCI(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func DeleteRepositoryFromCI(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	user, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err
@@ -112,7 +112,7 @@ func DeleteRepositoryFromCI(pCtx context.Context, h *handlers.H, ctx *gin.Contex
 }
 
 // AddRepositoryToCI adds the repository to CI and subscribes the user to it.
-func AddRepositoryToCI(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func AddRepositoryToCI(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	user, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err
@@ -158,7 +158,7 @@ func AddRepositoryToCI(pCtx context.Context, h *handlers.H, ctx *gin.Context) (i
 }
 
 // AddRepositorySubscription adds a subscription for the user to the repo
-func AddRepositorySubscription(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func AddRepositorySubscription(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	user, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err
@@ -168,7 +168,7 @@ func AddRepositorySubscription(pCtx context.Context, h *handlers.H, ctx *gin.Con
 }
 
 // DeleteRepositorySubscription removes the subscription to the repository from the user account.
-func DeleteRepositorySubscription(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func DeleteRepositorySubscription(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	user, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err

--- a/api/uisvc/restapi/run.go
+++ b/api/uisvc/restapi/run.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CountRuns returns a count of the queue items by asking the datasvc for it.
-func CountRuns(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func CountRuns(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	count, err := h.Clients.Data.RunCount(ctx, ctx.GetString("repository"), ctx.GetString("sha"))
 	if err != nil {
 		return nil, 500, err
@@ -21,7 +21,7 @@ func CountRuns(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface
 }
 
 // ListRuns lists all the runs that were requested by the page/perPage parameters.
-func ListRuns(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func ListRuns(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	page, perPage, err := utils.ScopePagination(ctx.GetString("page"), ctx.GetString("perPage"))
 	if err != nil {
 		return nil, 500, err
@@ -36,7 +36,7 @@ func ListRuns(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{
 }
 
 // GetRun retrieves a run by id.
-func GetRun(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func GetRun(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	runID, err := strconv.ParseInt(ctx.GetString("run_id"), 10, 64)
 	if err != nil {
 		return nil, 500, errors.New(err)
@@ -51,7 +51,7 @@ func GetRun(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{},
 }
 
 // CancelRun cancels a run by id.
-func CancelRun(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func CancelRun(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	runID, err := strconv.ParseInt(ctx.GetString("run_id"), 10, 64)
 	if err != nil {
 		return nil, 500, errors.New(err)

--- a/api/uisvc/restapi/submission.go
+++ b/api/uisvc/restapi/submission.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetSubmission retrieves a submission by id
-func GetSubmission(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func GetSubmission(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	id, eErr := strconv.ParseInt(ctx.GetString("id"), 10, 64)
 	if eErr != nil {
 		return nil, 500, errors.New(eErr)
@@ -26,7 +26,7 @@ func GetSubmission(pCtx context.Context, h *handlers.H, ctx *gin.Context) (inter
 }
 
 // GetSubmissionRuns retrieves a submission's runs from the submission id
-func GetSubmissionRuns(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func GetSubmissionRuns(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	id, eErr := strconv.ParseInt(ctx.GetString("id"), 10, 64)
 	if eErr != nil {
 		return nil, 500, errors.New(eErr)
@@ -51,7 +51,7 @@ func GetSubmissionRuns(pCtx context.Context, h *handlers.H, ctx *gin.Context) (i
 }
 
 // GetSubmissionTasks retrieves a submission's task from the submission id
-func GetSubmissionTasks(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func GetSubmissionTasks(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	id, eErr := strconv.ParseInt(ctx.GetString("id"), 10, 64)
 	if eErr != nil {
 		return nil, 500, errors.New(eErr)
@@ -76,7 +76,7 @@ func GetSubmissionTasks(pCtx context.Context, h *handlers.H, ctx *gin.Context) (
 }
 
 // ListSubmissions lists the submissions with optional repository/sha filtering and pagination.
-func ListSubmissions(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func ListSubmissions(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	page, perPage, err := utils.ScopePagination(ctx.GetString("page"), ctx.GetString("perPage"))
 	if err != nil {
 		return nil, 500, err
@@ -91,7 +91,7 @@ func ListSubmissions(pCtx context.Context, h *handlers.H, ctx *gin.Context) (int
 }
 
 // CountSubmissions counts the submissions with optional repository/sha filtering.
-func CountSubmissions(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func CountSubmissions(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	count, err := h.Clients.Data.CountSubmissions(ctx, ctx.GetString("repository"), ctx.GetString("sha"))
 	if err != nil {
 		return nil, 500, err
@@ -101,7 +101,7 @@ func CountSubmissions(pCtx context.Context, h *handlers.H, ctx *gin.Context) (in
 }
 
 // CancelSubmission cancels a submission by ID.
-func CancelSubmission(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func CancelSubmission(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	id, eErr := strconv.ParseInt(ctx.GetString("id"), 10, 64)
 	if eErr != nil {
 		return nil, 500, errors.New(eErr)

--- a/api/uisvc/restapi/submit.go
+++ b/api/uisvc/restapi/submit.go
@@ -5,13 +5,12 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 	"github.com/tinyci/ci-agents/types"
 )
 
 // Submit powers a manual submission to the queuesvc.
-func Submit(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func Submit(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	repo := ctx.GetString("repository")
 	sha := ctx.GetString("sha")
 

--- a/api/uisvc/restapi/task.go
+++ b/api/uisvc/restapi/task.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ListTasks retrieves the task list.
-func ListTasks(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func ListTasks(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	page, perPage, err := utils.ScopePagination(ctx.GetString("page"), ctx.GetString("perPage"))
 	if err != nil {
 		return nil, 500, err
@@ -26,7 +26,7 @@ func ListTasks(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface
 }
 
 // CountTasks counts the task list with the supplied repo/sha filtering.
-func CountTasks(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func CountTasks(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	count, err := h.Clients.Data.CountTasks(ctx, ctx.GetString("repository"), ctx.GetString("sha"))
 	if err != nil {
 		return nil, 500, err
@@ -36,7 +36,7 @@ func CountTasks(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interfac
 }
 
 // GetRunsForTask retrieves all the runs by task id. Pagination rules are in effect.
-func GetRunsForTask(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func GetRunsForTask(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	id, eErr := strconv.ParseInt(ctx.GetString("id"), 10, 64)
 	if eErr != nil {
 		return nil, 500, errors.New(eErr)
@@ -56,7 +56,7 @@ func GetRunsForTask(pCtx context.Context, h *handlers.H, ctx *gin.Context) (inte
 }
 
 // CountRunsForTask counts all the runs by task ID.
-func CountRunsForTask(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func CountRunsForTask(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	id, eErr := strconv.ParseInt(ctx.GetString("id"), 10, 64)
 	if eErr != nil {
 		return nil, 500, errors.New(eErr)
@@ -71,7 +71,7 @@ func CountRunsForTask(pCtx context.Context, h *handlers.H, ctx *gin.Context) (in
 }
 
 // ListSubscribedTasksForUser lists only the tasks for the repositories the user is subscribed to.
-func ListSubscribedTasksForUser(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func ListSubscribedTasksForUser(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	page, perPage, err := utils.ScopePagination(ctx.GetString("page"), ctx.GetString("perPage"))
 	if err != nil {
 		return nil, 500, err
@@ -97,7 +97,7 @@ func ListSubscribedTasksForUser(pCtx context.Context, h *handlers.H, ctx *gin.Co
 }
 
 // CancelTask cancels a task by ID.
-func CancelTask(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func CancelTask(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	id, eErr := strconv.ParseInt(ctx.GetString("id"), 10, 64)
 	if eErr != nil {
 		return nil, 500, errors.New(eErr)

--- a/api/uisvc/restapi/testserver.go
+++ b/api/uisvc/restapi/testserver.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MakeUIServer makes a uisvc.
-func MakeUIServer(client github.Client) (*handlers.H, chan struct{}, *tinyci.Client, *tinyci.Client, *errors.Error) {
+func MakeUIServer(client github.Client) (*handlers.H, chan struct{}, *tinyci.Client, *tinyci.Client, error) {
 	h := &handlers.H{
 		Config: HandlerConfig{},
 		Service: config.Service{

--- a/api/uisvc/restapi/token.go
+++ b/api/uisvc/restapi/token.go
@@ -4,13 +4,12 @@ import (
 	"context"
 
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/handlers"
 )
 
 // GetToken obtains a new token from the db. If one is already set, you must
 // delete it before this will return a new one.
-func GetToken(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func GetToken(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	u, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err
@@ -25,7 +24,7 @@ func GetToken(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{
 }
 
 // DeleteToken removes the existing token for the user.
-func DeleteToken(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, *errors.Error) {
+func DeleteToken(pCtx context.Context, h *handlers.H, ctx *gin.Context) (interface{}, int, error) {
 	u, err := h.GetUser(ctx)
 	if err != nil {
 		return nil, 500, err

--- a/ci-gen/gen/client/uisvc/client/operations/operations_client.go
+++ b/ci-gen/gen/client/uisvc/client/operations/operations_client.go
@@ -33,7 +33,7 @@ type Client struct {
 
 // New creates a new *Client. Passing a cert will enable client/server
 // certificate authentication; otherwise pass nil for no auth.
-func New(baseURL string, token string, cert *transport.Cert) (*Client, *errors.Error) {
+func New(baseURL string, token string, cert *transport.Cert) (*Client, error) {
 	t, err := transport.NewHTTP(cert)
 	if err != nil {
 		return nil, errors.New(err)
@@ -70,7 +70,7 @@ func (c *Client) UnmarshalCookies(content []byte) error {
 }
 
 // DeleteCapabilitiesUsernameCapability remove a named capability
-func (c *Client) DeleteCapabilitiesUsernameCapability(ctx context.Context, capability string, username string) *errors.Error {
+func (c *Client) DeleteCapabilitiesUsernameCapability(ctx context.Context, capability string, username string) error {
 	route := "/capabilities/{username}/{capability}"
 	route = strings.Replace(route, "{capability}", url.PathEscape(fmt.Sprintf("%v", capability)), -1)
 
@@ -123,7 +123,7 @@ func (c *Client) DeleteCapabilitiesUsernameCapability(ctx context.Context, capab
 }
 
 // DeleteToken remove and reset your tiny c i access token
-func (c *Client) DeleteToken(ctx context.Context) *errors.Error {
+func (c *Client) DeleteToken(ctx context.Context) error {
 	route := "/token"
 
 	tmp := *c.url
@@ -173,7 +173,7 @@ func (c *Client) DeleteToken(ctx context.Context) *errors.Error {
 }
 
 // GetErrors retrieve errors
-func (c *Client) GetErrors(ctx context.Context) ([]*models.UserError, *errors.Error) {
+func (c *Client) GetErrors(ctx context.Context) ([]*models.UserError, error) {
 	route := "/errors"
 
 	tmp := *c.url
@@ -229,7 +229,7 @@ func (c *Client) GetErrors(ctx context.Context) ([]*models.UserError, *errors.Er
 }
 
 // GetLogAttachID attach to a running log
-func (c *Client) GetLogAttachID(ctx context.Context, id int64, w io.WriteCloser) *errors.Error {
+func (c *Client) GetLogAttachID(ctx context.Context, id int64, w io.WriteCloser) error {
 	route := "/log/attach/{id}"
 	route = strings.Replace(route, "{id}", url.PathEscape(fmt.Sprintf("%v", id)), -1)
 
@@ -272,7 +272,7 @@ func (c *Client) GetLogAttachID(ctx context.Context, id int64, w io.WriteCloser)
 }
 
 // GetLoggedin check logged in state
-func (c *Client) GetLoggedin(ctx context.Context) (string, *errors.Error) {
+func (c *Client) GetLoggedin(ctx context.Context) (string, error) {
 	route := "/loggedin"
 
 	tmp := *c.url
@@ -328,7 +328,7 @@ func (c *Client) GetLoggedin(ctx context.Context) (string, *errors.Error) {
 }
 
 // GetLogin log into the system
-func (c *Client) GetLogin(ctx context.Context, code string, state string) *errors.Error {
+func (c *Client) GetLogin(ctx context.Context, code string, state string) error {
 	route := "/login"
 
 	tmp := *c.url
@@ -381,7 +381,7 @@ func (c *Client) GetLogin(ctx context.Context, code string, state string) *error
 }
 
 // GetLoginUpgrade log into the system with upgraded permissions
-func (c *Client) GetLoginUpgrade(ctx context.Context) *errors.Error {
+func (c *Client) GetLoginUpgrade(ctx context.Context) error {
 	route := "/login/upgrade"
 
 	tmp := *c.url
@@ -431,7 +431,7 @@ func (c *Client) GetLoginUpgrade(ctx context.Context) *errors.Error {
 }
 
 // GetLogout log out of the system
-func (c *Client) GetLogout(ctx context.Context) *errors.Error {
+func (c *Client) GetLogout(ctx context.Context) error {
 	route := "/logout"
 
 	tmp := *c.url
@@ -481,7 +481,7 @@ func (c *Client) GetLogout(ctx context.Context) *errors.Error {
 }
 
 // GetRepositoriesCiAddOwnerRepo add a specific repository to c i
-func (c *Client) GetRepositoriesCiAddOwnerRepo(ctx context.Context, owner string, repo string) *errors.Error {
+func (c *Client) GetRepositoriesCiAddOwnerRepo(ctx context.Context, owner string, repo string) error {
 	route := "/repositories/ci/add/{owner}/{repo}"
 	route = strings.Replace(route, "{owner}", url.PathEscape(fmt.Sprintf("%v", owner)), -1)
 
@@ -534,7 +534,7 @@ func (c *Client) GetRepositoriesCiAddOwnerRepo(ctx context.Context, owner string
 }
 
 // GetRepositoriesCiDelOwnerRepo removes a specific repository from c i
-func (c *Client) GetRepositoriesCiDelOwnerRepo(ctx context.Context, owner string, repo string) *errors.Error {
+func (c *Client) GetRepositoriesCiDelOwnerRepo(ctx context.Context, owner string, repo string) error {
 	route := "/repositories/ci/del/{owner}/{repo}"
 	route = strings.Replace(route, "{owner}", url.PathEscape(fmt.Sprintf("%v", owner)), -1)
 
@@ -587,7 +587,7 @@ func (c *Client) GetRepositoriesCiDelOwnerRepo(ctx context.Context, owner string
 }
 
 // GetRepositoriesMy fetch all the writable repositories for the user
-func (c *Client) GetRepositoriesMy(ctx context.Context, search string) (models.RepositoryList, *errors.Error) {
+func (c *Client) GetRepositoriesMy(ctx context.Context, search string) (models.RepositoryList, error) {
 	route := "/repositories/my"
 
 	tmp := *c.url
@@ -644,7 +644,7 @@ func (c *Client) GetRepositoriesMy(ctx context.Context, search string) (models.R
 }
 
 // GetRepositoriesScan scan repositories from the remote resource
-func (c *Client) GetRepositoriesScan(ctx context.Context) *errors.Error {
+func (c *Client) GetRepositoriesScan(ctx context.Context) error {
 	route := "/repositories/scan"
 
 	tmp := *c.url
@@ -694,7 +694,7 @@ func (c *Client) GetRepositoriesScan(ctx context.Context) *errors.Error {
 }
 
 // GetRepositoriesSubAddOwnerRepo subscribe to a repository running c i
-func (c *Client) GetRepositoriesSubAddOwnerRepo(ctx context.Context, owner string, repo string) *errors.Error {
+func (c *Client) GetRepositoriesSubAddOwnerRepo(ctx context.Context, owner string, repo string) error {
 	route := "/repositories/sub/add/{owner}/{repo}"
 	route = strings.Replace(route, "{owner}", url.PathEscape(fmt.Sprintf("%v", owner)), -1)
 
@@ -747,7 +747,7 @@ func (c *Client) GetRepositoriesSubAddOwnerRepo(ctx context.Context, owner strin
 }
 
 // GetRepositoriesSubDelOwnerRepo unsubscribe from a repository
-func (c *Client) GetRepositoriesSubDelOwnerRepo(ctx context.Context, owner string, repo string) *errors.Error {
+func (c *Client) GetRepositoriesSubDelOwnerRepo(ctx context.Context, owner string, repo string) error {
 	route := "/repositories/sub/del/{owner}/{repo}"
 	route = strings.Replace(route, "{owner}", url.PathEscape(fmt.Sprintf("%v", owner)), -1)
 
@@ -800,7 +800,7 @@ func (c *Client) GetRepositoriesSubDelOwnerRepo(ctx context.Context, owner strin
 }
 
 // GetRepositoriesSubscribed list all subscribed repositories
-func (c *Client) GetRepositoriesSubscribed(ctx context.Context, search string) (models.RepositoryList, *errors.Error) {
+func (c *Client) GetRepositoriesSubscribed(ctx context.Context, search string) (models.RepositoryList, error) {
 	route := "/repositories/subscribed"
 
 	tmp := *c.url
@@ -857,7 +857,7 @@ func (c *Client) GetRepositoriesSubscribed(ctx context.Context, search string) (
 }
 
 // GetRepositoriesVisible fetch all the repositories the user can view
-func (c *Client) GetRepositoriesVisible(ctx context.Context, search string) (models.RepositoryList, *errors.Error) {
+func (c *Client) GetRepositoriesVisible(ctx context.Context, search string) (models.RepositoryList, error) {
 	route := "/repositories/visible"
 
 	tmp := *c.url
@@ -914,7 +914,7 @@ func (c *Client) GetRepositoriesVisible(ctx context.Context, search string) (mod
 }
 
 // GetRunRunID get a run by ID
-func (c *Client) GetRunRunID(ctx context.Context, runID int64) (*models.Run, *errors.Error) {
+func (c *Client) GetRunRunID(ctx context.Context, runID int64) (*models.Run, error) {
 	route := "/run/{run_id}"
 	route = strings.Replace(route, "{run_id}", url.PathEscape(fmt.Sprintf("%v", runID)), -1)
 
@@ -971,7 +971,7 @@ func (c *Client) GetRunRunID(ctx context.Context, runID int64) (*models.Run, *er
 }
 
 // GetRuns obtain the run list for the user
-func (c *Client) GetRuns(ctx context.Context, page int64, perPage int64, repository string, sha string) (models.RunList, *errors.Error) {
+func (c *Client) GetRuns(ctx context.Context, page int64, perPage int64, repository string, sha string) (models.RunList, error) {
 	route := "/runs"
 
 	tmp := *c.url
@@ -1034,7 +1034,7 @@ func (c *Client) GetRuns(ctx context.Context, page int64, perPage int64, reposit
 }
 
 // GetRunsCount count the runs
-func (c *Client) GetRunsCount(ctx context.Context, repository string, sha string) (int64, *errors.Error) {
+func (c *Client) GetRunsCount(ctx context.Context, repository string, sha string) (int64, error) {
 	route := "/runs/count"
 
 	tmp := *c.url
@@ -1093,7 +1093,7 @@ func (c *Client) GetRunsCount(ctx context.Context, repository string, sha string
 }
 
 // GetSubmissionID get a submission by ID
-func (c *Client) GetSubmissionID(ctx context.Context, id int64) (*models.ModelSubmission, *errors.Error) {
+func (c *Client) GetSubmissionID(ctx context.Context, id int64) (*models.ModelSubmission, error) {
 	route := "/submission/{id}"
 	route = strings.Replace(route, "{id}", url.PathEscape(fmt.Sprintf("%v", id)), -1)
 
@@ -1150,7 +1150,7 @@ func (c *Client) GetSubmissionID(ctx context.Context, id int64) (*models.ModelSu
 }
 
 // GetSubmissionIDRuns get submission runs by ID
-func (c *Client) GetSubmissionIDRuns(ctx context.Context, id int64, page int64, perPage int64) (models.RunList, *errors.Error) {
+func (c *Client) GetSubmissionIDRuns(ctx context.Context, id int64, page int64, perPage int64) (models.RunList, error) {
 	route := "/submission/{id}/runs"
 	route = strings.Replace(route, "{id}", url.PathEscape(fmt.Sprintf("%v", id)), -1)
 
@@ -1211,7 +1211,7 @@ func (c *Client) GetSubmissionIDRuns(ctx context.Context, id int64, page int64, 
 }
 
 // GetSubmissionIDTasks get submission tasks by ID
-func (c *Client) GetSubmissionIDTasks(ctx context.Context, id int64, page int64, perPage int64) (models.TaskList, *errors.Error) {
+func (c *Client) GetSubmissionIDTasks(ctx context.Context, id int64, page int64, perPage int64) (models.TaskList, error) {
 	route := "/submission/{id}/tasks"
 	route = strings.Replace(route, "{id}", url.PathEscape(fmt.Sprintf("%v", id)), -1)
 
@@ -1272,7 +1272,7 @@ func (c *Client) GetSubmissionIDTasks(ctx context.Context, id int64, page int64,
 }
 
 // GetSubmissions list submisssions
-func (c *Client) GetSubmissions(ctx context.Context, page int64, perPage int64, repository string, sha string) (models.ModelSubmissionList, *errors.Error) {
+func (c *Client) GetSubmissions(ctx context.Context, page int64, perPage int64, repository string, sha string) (models.ModelSubmissionList, error) {
 	route := "/submissions"
 
 	tmp := *c.url
@@ -1335,7 +1335,7 @@ func (c *Client) GetSubmissions(ctx context.Context, page int64, perPage int64, 
 }
 
 // GetSubmissionsCount count submisssions
-func (c *Client) GetSubmissionsCount(ctx context.Context, repository string, sha string) (int64, *errors.Error) {
+func (c *Client) GetSubmissionsCount(ctx context.Context, repository string, sha string) (int64, error) {
 	route := "/submissions/count"
 
 	tmp := *c.url
@@ -1394,7 +1394,7 @@ func (c *Client) GetSubmissionsCount(ctx context.Context, repository string, sha
 }
 
 // GetSubmit perform a manual submission to tiny c i
-func (c *Client) GetSubmit(ctx context.Context, all bool, repository string, sha string) *errors.Error {
+func (c *Client) GetSubmit(ctx context.Context, all bool, repository string, sha string) error {
 	route := "/submit"
 
 	tmp := *c.url
@@ -1449,7 +1449,7 @@ func (c *Client) GetSubmit(ctx context.Context, all bool, repository string, sha
 }
 
 // GetTasks obtain the task list optionally filtering by repository and sha
-func (c *Client) GetTasks(ctx context.Context, page int64, perPage int64, repository string, sha string) (models.TaskList, *errors.Error) {
+func (c *Client) GetTasks(ctx context.Context, page int64, perPage int64, repository string, sha string) (models.TaskList, error) {
 	route := "/tasks"
 
 	tmp := *c.url
@@ -1512,7 +1512,7 @@ func (c *Client) GetTasks(ctx context.Context, page int64, perPage int64, reposi
 }
 
 // GetTasksCount count the tasks
-func (c *Client) GetTasksCount(ctx context.Context, repository string, sha string) (int64, *errors.Error) {
+func (c *Client) GetTasksCount(ctx context.Context, repository string, sha string) (int64, error) {
 	route := "/tasks/count"
 
 	tmp := *c.url
@@ -1571,7 +1571,7 @@ func (c *Client) GetTasksCount(ctx context.Context, repository string, sha strin
 }
 
 // GetTasksRunsID obtain the run list based on the task ID
-func (c *Client) GetTasksRunsID(ctx context.Context, id int64, page int64, perPage int64) (models.RunList, *errors.Error) {
+func (c *Client) GetTasksRunsID(ctx context.Context, id int64, page int64, perPage int64) (models.RunList, error) {
 	route := "/tasks/runs/{id}"
 	route = strings.Replace(route, "{id}", url.PathEscape(fmt.Sprintf("%v", id)), -1)
 
@@ -1632,7 +1632,7 @@ func (c *Client) GetTasksRunsID(ctx context.Context, id int64, page int64, perPa
 }
 
 // GetTasksRunsIDCount count the runs corresponding to the task ID
-func (c *Client) GetTasksRunsIDCount(ctx context.Context, id int64) (int64, *errors.Error) {
+func (c *Client) GetTasksRunsIDCount(ctx context.Context, id int64) (int64, error) {
 	route := "/tasks/runs/{id}/count"
 	route = strings.Replace(route, "{id}", url.PathEscape(fmt.Sprintf("%v", id)), -1)
 
@@ -1689,7 +1689,7 @@ func (c *Client) GetTasksRunsIDCount(ctx context.Context, id int64) (int64, *err
 }
 
 // GetTasksSubscribed obtain the list of tasks that belong to repositories you are subscribed to
-func (c *Client) GetTasksSubscribed(ctx context.Context, page int64, perPage int64) (models.TaskList, *errors.Error) {
+func (c *Client) GetTasksSubscribed(ctx context.Context, page int64, perPage int64) (models.TaskList, error) {
 	route := "/tasks/subscribed"
 
 	tmp := *c.url
@@ -1748,7 +1748,7 @@ func (c *Client) GetTasksSubscribed(ctx context.Context, page int64, perPage int
 }
 
 // GetToken get a tiny c i access token
-func (c *Client) GetToken(ctx context.Context) (string, *errors.Error) {
+func (c *Client) GetToken(ctx context.Context) (string, error) {
 	route := "/token"
 
 	tmp := *c.url
@@ -1804,7 +1804,7 @@ func (c *Client) GetToken(ctx context.Context) (string, *errors.Error) {
 }
 
 // GetUserProperties get information about the current user
-func (c *Client) GetUserProperties(ctx context.Context) (interface{}, *errors.Error) {
+func (c *Client) GetUserProperties(ctx context.Context) (interface{}, error) {
 	route := "/user/properties"
 
 	tmp := *c.url
@@ -1860,7 +1860,7 @@ func (c *Client) GetUserProperties(ctx context.Context) (interface{}, *errors.Er
 }
 
 // PostCancelRunID cancel by run ID
-func (c *Client) PostCancelRunID(ctx context.Context, runID int64) *errors.Error {
+func (c *Client) PostCancelRunID(ctx context.Context, runID int64) error {
 	route := "/cancel/{run_id}"
 	route = strings.Replace(route, "{run_id}", url.PathEscape(fmt.Sprintf("%v", runID)), -1)
 
@@ -1916,7 +1916,7 @@ func (c *Client) PostCancelRunID(ctx context.Context, runID int64) *errors.Error
 }
 
 // PostCapabilitiesUsernameCapability add a named capability
-func (c *Client) PostCapabilitiesUsernameCapability(ctx context.Context, capability string, username string) *errors.Error {
+func (c *Client) PostCapabilitiesUsernameCapability(ctx context.Context, capability string, username string) error {
 	route := "/capabilities/{username}/{capability}"
 	route = strings.Replace(route, "{capability}", url.PathEscape(fmt.Sprintf("%v", capability)), -1)
 
@@ -1974,7 +1974,7 @@ func (c *Client) PostCapabilitiesUsernameCapability(ctx context.Context, capabil
 }
 
 // PostSubmissionIDCancel cancel a submission by ID
-func (c *Client) PostSubmissionIDCancel(ctx context.Context, id int64) *errors.Error {
+func (c *Client) PostSubmissionIDCancel(ctx context.Context, id int64) error {
 	route := "/submission/{id}/cancel"
 	route = strings.Replace(route, "{id}", url.PathEscape(fmt.Sprintf("%v", id)), -1)
 
@@ -2030,7 +2030,7 @@ func (c *Client) PostSubmissionIDCancel(ctx context.Context, id int64) *errors.E
 }
 
 // PostTasksCancelID cancel by task ID
-func (c *Client) PostTasksCancelID(ctx context.Context, id int64) *errors.Error {
+func (c *Client) PostTasksCancelID(ctx context.Context, id int64) error {
 	route := "/tasks/cancel/{id}"
 	route = strings.Replace(route, "{id}", url.PathEscape(fmt.Sprintf("%v", id)), -1)
 

--- a/ci-gen/grpc/handler/handler.go
+++ b/ci-gen/grpc/handler/handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/tinyci/ci-agents/config"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/model"
 	"github.com/tinyci/ci-agents/utils"
 	"google.golang.org/grpc"
@@ -21,7 +20,7 @@ type H struct {
 }
 
 // CreateServer creates the grpc server
-func (h *H) CreateServer() (*grpc.Server, io.Closer, *errors.Error) {
+func (h *H) CreateServer() (*grpc.Server, io.Closer, error) {
 	if h.EnableTracing {
 		closer, err := utils.CreateTracer(h.Name)
 		if err != nil {
@@ -39,9 +38,9 @@ func (h *H) CreateServer() (*grpc.Server, io.Closer, *errors.Error) {
 }
 
 // Boot boots the service. It returns a done channel for closing and any errors.
-func (h *H) Boot(t net.Listener, s *grpc.Server, finished chan struct{}) (chan struct{}, *errors.Error) {
+func (h *H) Boot(t net.Listener, s *grpc.Server, finished chan struct{}) (chan struct{}, error) {
 	if h.Service.UseDB {
-		var err *errors.Error
+		var err error
 		h.Model, err = model.New(h.UserConfig.DSN)
 		if err != nil {
 			return nil, err
@@ -52,7 +51,7 @@ func (h *H) Boot(t net.Listener, s *grpc.Server, finished chan struct{}) (chan s
 		return nil, err
 	}
 
-	var err *errors.Error
+	var err error
 	h.Clients, err = h.UserConfig.ClientConfig.CreateClients(h.UserConfig, h.Name)
 	if err != nil {
 		return nil, err

--- a/ci-gen/swagger/templates/client/client.gotmpl
+++ b/ci-gen/swagger/templates/client/client.gotmpl
@@ -31,7 +31,7 @@ type Client struct {
 
 // New creates a new *Client. Passing a cert will enable client/server
 // certificate authentication; otherwise pass nil for no auth.
-func New(baseURL string, token string, cert *transport.Cert) (*Client, *errors.Error) {
+func New(baseURL string, token string, cert *transport.Cert) (*Client, error) {
   t, err := transport.NewHTTP(cert)
   if err != nil {
     return nil, errors.New(err)
@@ -77,7 +77,7 @@ func (c *Client) {{ pascalize .Name }}(ctx context.Context {{- range $param := .
 {{- .SuccessResponse.Schema.GoType }},
 {{- end }}
 {{- end }}
-{{- end }}*errors.Error) {
+{{- end }}error) {
   route := {{ printf "%q" .Path }}
 
   {{- range $param := .Params }}

--- a/ci-gen/swagger/templates/server/configureapi.gotmpl
+++ b/ci-gen/swagger/templates/server/configureapi.gotmpl
@@ -26,22 +26,22 @@ func MakeHandlerConfig(sc config.ServiceConfig) *HandlerConfig {
 }
 
 // Validate allows you to perform your own custom validations on the configuration.
-func (hc HandlerConfig) Validate(h *handlers.H) *errors.Error {
+func (hc HandlerConfig) Validate(h *handlers.H) error {
   return nil
 }
 
 // CustomInit allows you to perform any final magic before boot.
-func (hc HandlerConfig) CustomInit(h *handlers.H) *errors.Error {
+func (hc HandlerConfig) CustomInit(h *handlers.H) error {
   return nil
 }
 
 // DBConfigure configures the database if necessary.
-func (hc HandlerConfig) DBConfigure(h *handlers.H) *errors.Error {
+func (hc HandlerConfig) DBConfigure(h *handlers.H) error {
   return nil
 }
 
 // Configure allows you to configure the routes, in particular. Setting the
 // processing functions here will be a big part of your day job.
-func (hc HandlerConfig) Configure(router handlers.Routes) *errors.Error {
+func (hc HandlerConfig) Configure(router handlers.Routes) error {
   return nil
 }

--- a/ci-gen/swagger/templates/server/main.gotmpl
+++ b/ci-gen/swagger/templates/server/main.gotmpl
@@ -40,9 +40,6 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-    if e, ok := err.(*errors.Error); ok && e == nil {
-      return
-    }
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/ci-gen/swagger/templates/server/operation.gotmpl
+++ b/ci-gen/swagger/templates/server/operation.gotmpl
@@ -31,14 +31,14 @@ import (
 // {{pascalize .Name }} swagger:route {{ .Method }} {{ .Path }}{{ range .Tags }} {{ . }}{{ end }} {{ camelize .Name }}
 // {{ if .Summary }}{{ comment .Summary }}{{ end }}
 {{ if .Description }}// {{ comment .Description }}{{ end }}
-func {{ .Name }}(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) *errors.Error {
+func {{ .Name }}(h *handlers.H, ctx *gin.Context, processingHandler handlers.HandlerFunc) error {
   if h.RequestLogging {
     start := time.Now()
     u := uuid.New()
 
     content, jsonErr := json.Marshal(ctx.Params)
     if jsonErr != nil { 
-      h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).Wrap("encoding params for log message"))
+      h.Clients.Log.Error(ctx.Request.Context(), errors.New(jsonErr).(errors.Error).Wrap("encoding params for log message"))
     }
 
     logger := h.Clients.Log.WithRequest(ctx.Request).WithFields(log.FieldMap{

--- a/ci-gen/swagger/templates/server/parameter.gotmpl
+++ b/ci-gen/swagger/templates/server/parameter.gotmpl
@@ -10,7 +10,7 @@ import (
 
 // {{ pascalize $op.Name }}ValidateURLParams validates the parameters in the
 // URL according to the swagger specification.
-func {{ pascalize $op.Name }}ValidateURLParams(h *handlers.H, ctx *gin.Context) *errors.Error {
+func {{ pascalize $op.Name }}ValidateURLParams(h *handlers.H, ctx *gin.Context) error {
   {{- range $obj := .Params }}
   {{- if eq $obj.Location "query" }}
   {{ varname $obj.Name }} := {{ printf "ctx.Query(%q)" $obj.Name }}

--- a/ci-gen/swagger/templates/server/responses.gotmpl
+++ b/ci-gen/swagger/templates/server/responses.gotmpl
@@ -11,7 +11,7 @@ import (
 // Editing this file might prove futile when you re-run the swagger generate command
 
 // {{ pascalize .Name }}Response responds for {{ pascalize .Name }}.
-func {{ .Name }}Response(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err *errors.Error) *errors.Error {
+func {{ .Name }}Response(h *handlers.H, ctx *gin.Context, resp interface{}, code int, err error) error {
   if err != nil {
     h.LogError(err, ctx, code)
     return err

--- a/clients/asset/asset.go
+++ b/clients/asset/asset.go
@@ -19,11 +19,11 @@ type Client struct {
 }
 
 // NewClient creates a new *Client for use.
-func NewClient(addr string, cert *transport.Cert, trace bool) (*Client, *errors.Error) {
+func NewClient(addr string, cert *transport.Cert, trace bool) (*Client, error) {
 	var (
 		closer  io.Closer
 		options []grpc.DialOption
-		eErr    *errors.Error
+		eErr    error
 	)
 
 	if trace {
@@ -50,7 +50,7 @@ func (c *Client) Close() error {
 }
 
 // Write writes a log at id with the supplied reader providing the content.
-func (c *Client) Write(ctx context.Context, id int64, f io.Reader) *errors.Error {
+func (c *Client) Write(ctx context.Context, id int64, f io.Reader) error {
 	s, err := c.ac.PutLog(ctx, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
@@ -88,7 +88,7 @@ func (c *Client) Write(ctx context.Context, id int64, f io.Reader) *errors.Error
 	}
 }
 
-func (c *Client) Read(ctx context.Context, id int64, w io.Writer) *errors.Error {
+func (c *Client) Read(ctx context.Context, id int64, w io.Writer) error {
 	as, err := c.ac.GetLog(ctx, &types.IntID{ID: id}, grpc.WaitForReady(false))
 	if err != nil {
 		return errors.New(err)

--- a/clients/auth/auth.go
+++ b/clients/auth/auth.go
@@ -19,11 +19,11 @@ type Client struct {
 }
 
 // NewClient creates a new *Client for use.
-func NewClient(addr string, cert *transport.Cert, trace bool) (*Client, *errors.Error) {
+func NewClient(addr string, cert *transport.Cert, trace bool) (*Client, error) {
 	var (
 		closer  io.Closer
 		options []grpc.DialOption
-		eErr    *errors.Error
+		eErr    error
 	)
 
 	if trace {
@@ -51,7 +51,7 @@ func (c *Client) Close() error {
 }
 
 // Capabilities notes what types of auth this server supports.
-func (c *Client) Capabilities(ctx context.Context) ([]string, *errors.Error) {
+func (c *Client) Capabilities(ctx context.Context) ([]string, error) {
 	caps, err := c.ac.Capabilities(ctx, &empty.Empty{})
 	if err != nil {
 		return nil, errors.New(err)

--- a/clients/auth/oauth.go
+++ b/clients/auth/oauth.go
@@ -8,7 +8,7 @@ import (
 )
 
 // OAuthChallenge handles oauth codes and on success, returns the user (Created or patched with latest token)
-func (c *Client) OAuthChallenge(ctx context.Context, state, code string) (*auth.OAuthInfo, *errors.Error) {
+func (c *Client) OAuthChallenge(ctx context.Context, state, code string) (*auth.OAuthInfo, error) {
 	userinfo, err := c.ac.OAuthChallenge(ctx, &auth.OAuthChallengeRequest{Code: code, State: state})
 	if err != nil {
 		return nil, errors.New(err)
@@ -18,7 +18,7 @@ func (c *Client) OAuthChallenge(ctx context.Context, state, code string) (*auth.
 }
 
 // GetOAuthURL retrieves the OAuth redirection URL based on the provided requirements.
-func (c *Client) GetOAuthURL(ctx context.Context, scopes []string) (string, *errors.Error) {
+func (c *Client) GetOAuthURL(ctx context.Context, scopes []string) (string, error) {
 	str, err := c.ac.GetOAuthURL(ctx, &auth.Scopes{List: scopes})
 	if err != nil {
 		return "", errors.New(err)

--- a/clients/data/client.go
+++ b/clients/data/client.go
@@ -17,11 +17,11 @@ type Client struct {
 }
 
 // New creates a new *Client.
-func New(addr string, cert *transport.Cert, trace bool) (*Client, *errors.Error) {
+func New(addr string, cert *transport.Cert, trace bool) (*Client, error) {
 	var (
 		closer  io.Closer
 		options []grpc.DialOption
-		eErr    *errors.Error
+		eErr    error
 	)
 
 	if trace {

--- a/clients/data/errors.go
+++ b/clients/data/errors.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetErrors retrieves all the errors for the user.
-func (c *Client) GetErrors(ctx context.Context, name string) ([]*model.UserError, *errors.Error) {
+func (c *Client) GetErrors(ctx context.Context, name string) ([]*model.UserError, error) {
 	errs, err := c.client.GetErrors(ctx, &data.Name{Name: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -27,7 +27,7 @@ func (c *Client) GetErrors(ctx context.Context, name string) ([]*model.UserError
 }
 
 // AddError adds an error.
-func (c *Client) AddError(ctx context.Context, msg, username string) *errors.Error {
+func (c *Client) AddError(ctx context.Context, msg, username string) error {
 	u, err := c.client.UserByName(ctx, &data.Name{Name: username}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
@@ -42,7 +42,7 @@ func (c *Client) AddError(ctx context.Context, msg, username string) *errors.Err
 }
 
 // DeleteError removes an error.
-func (c *Client) DeleteError(ctx context.Context, id, userID int64) *errors.Error {
+func (c *Client) DeleteError(ctx context.Context, id, userID int64) error {
 	_, err := c.client.DeleteError(ctx, &types.UserError{Id: id, UserID: userID}, grpc.WaitForReady(true))
 	return errors.New(err)
 }

--- a/clients/data/oauth.go
+++ b/clients/data/oauth.go
@@ -9,7 +9,7 @@ import (
 )
 
 // OAuthValidateState validates the state in the database.
-func (c *Client) OAuthValidateState(ctx context.Context, state string) ([]string, *errors.Error) {
+func (c *Client) OAuthValidateState(ctx context.Context, state string) ([]string, error) {
 	oas, err := c.client.OAuthValidateState(ctx, &data.OAuthState{State: state}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -19,7 +19,7 @@ func (c *Client) OAuthValidateState(ctx context.Context, state string) ([]string
 }
 
 // OAuthRegisterState registers the oauth state in the database.
-func (c *Client) OAuthRegisterState(ctx context.Context, state string, scopes []string) *errors.Error {
+func (c *Client) OAuthRegisterState(ctx context.Context, state string, scopes []string) error {
 	_, err := c.client.OAuthRegisterState(ctx, &data.OAuthState{State: state, Scopes: scopes}, grpc.WaitForReady(true))
 	return errors.New(err)
 }

--- a/clients/data/queue.go
+++ b/clients/data/queue.go
@@ -12,7 +12,7 @@ import (
 
 // NextQueueItem return the next queue item. The runningOn is a hostname which
 // is provided for tracking purposes. It should be unique (but, is ultimately not necessary).
-func (c *Client) NextQueueItem(ctx context.Context, queueName, runningOn string) (*model.QueueItem, *errors.Error) {
+func (c *Client) NextQueueItem(ctx context.Context, queueName, runningOn string) (*model.QueueItem, error) {
 	item, err := c.client.QueueNext(ctx, &types.QueueRequest{QueueName: queueName, RunningOn: runningOn}, grpc.WaitForReady(false))
 	if err != nil {
 		return nil, errors.New(err)
@@ -22,13 +22,13 @@ func (c *Client) NextQueueItem(ctx context.Context, queueName, runningOn string)
 }
 
 // PutStatus returns the status of the run.
-func (c *Client) PutStatus(ctx context.Context, runID int64, status bool, msg string) *errors.Error {
+func (c *Client) PutStatus(ctx context.Context, runID int64, status bool, msg string) error {
 	_, err := c.client.PutStatus(ctx, &types.Status{AdditionalMessage: msg, Id: runID, Status: status}, grpc.WaitForReady(true))
 	return errors.New(err)
 }
 
 // PutQueue adds many QueueItems to the queue.
-func (c *Client) PutQueue(ctx context.Context, qis []*model.QueueItem) ([]*model.QueueItem, *errors.Error) {
+func (c *Client) PutQueue(ctx context.Context, qis []*model.QueueItem) ([]*model.QueueItem, error) {
 	ql := &data.QueueList{}
 
 	for _, qi := range qis {
@@ -55,13 +55,13 @@ func (c *Client) PutQueue(ctx context.Context, qis []*model.QueueItem) ([]*model
 }
 
 // SetCancel cancels a run, and any other task-level runs.
-func (c *Client) SetCancel(ctx context.Context, id int64) *errors.Error {
+func (c *Client) SetCancel(ctx context.Context, id int64) error {
 	_, err := c.client.SetCancel(ctx, &types.IntID{ID: id}, grpc.WaitForReady(true))
 	return errors.New(err)
 }
 
 // GetCancel returns the state for the run.
-func (c *Client) GetCancel(ctx context.Context, id int64) (bool, *errors.Error) {
+func (c *Client) GetCancel(ctx context.Context, id int64) (bool, error) {
 	status, err := c.client.GetCancel(ctx, &types.IntID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return false, errors.New(err)

--- a/clients/data/ref.go
+++ b/clients/data/ref.go
@@ -10,7 +10,7 @@ import (
 )
 
 // PutRef adds a ref to the database.
-func (c *Client) PutRef(ctx context.Context, ref *model.Ref) (int64, *errors.Error) {
+func (c *Client) PutRef(ctx context.Context, ref *model.Ref) (int64, error) {
 	id, err := c.client.PutRef(ctx, ref.ToProto(), grpc.WaitForReady(true))
 	if err != nil {
 		return 0, errors.New(err)
@@ -20,13 +20,13 @@ func (c *Client) PutRef(ctx context.Context, ref *model.Ref) (int64, *errors.Err
 }
 
 // CancelRefByName cancels all jobs for a ref by name
-func (c *Client) CancelRefByName(ctx context.Context, repoID int64, ref string) *errors.Error {
+func (c *Client) CancelRefByName(ctx context.Context, repoID int64, ref string) error {
 	_, err := c.client.CancelRefByName(ctx, &data.RepoRef{Repository: repoID, RefName: ref}, grpc.WaitForReady(true))
 	return errors.New(err)
 }
 
 // GetRefByNameAndSHA retrieves a ref by it's repo name and SHA
-func (c *Client) GetRefByNameAndSHA(ctx context.Context, repoName, sha string) (*model.Ref, *errors.Error) {
+func (c *Client) GetRefByNameAndSHA(ctx context.Context, repoName, sha string) (*model.Ref, error) {
 	ref, err := c.client.GetRefByNameAndSHA(ctx, &data.RefPair{RepoName: repoName, Sha: sha}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)

--- a/clients/data/repository.go
+++ b/clients/data/repository.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func makeRepoList(list *types.RepositoryList) (model.RepositoryList, *errors.Error) {
+func makeRepoList(list *types.RepositoryList) (model.RepositoryList, error) {
 	rl := model.RepositoryList{}
 
 	for _, repo := range list.List {
@@ -28,7 +28,7 @@ func makeRepoList(list *types.RepositoryList) (model.RepositoryList, *errors.Err
 }
 
 // GetRepository retrieves a repository by name.
-func (c *Client) GetRepository(ctx context.Context, name string) (*model.Repository, *errors.Error) {
+func (c *Client) GetRepository(ctx context.Context, name string) (*model.Repository, error) {
 	repo, err := c.client.GetRepository(ctx, &data.Name{Name: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -38,7 +38,7 @@ func (c *Client) GetRepository(ctx context.Context, name string) (*model.Reposit
 }
 
 // PutRepositories takes a list of github repositories and adds them to the database for the user as owner.
-func (c *Client) PutRepositories(ctx context.Context, name string, github []*github.Repository, autoCreated bool) *errors.Error {
+func (c *Client) PutRepositories(ctx context.Context, name string, github []*github.Repository, autoCreated bool) error {
 	content, err := json.Marshal(github)
 	if err != nil {
 		return errors.New(err)
@@ -53,7 +53,7 @@ func (c *Client) PutRepositories(ctx context.Context, name string, github []*git
 }
 
 // EnableRepository enables a repository in CI for a user as owner.
-func (c *Client) EnableRepository(ctx context.Context, user, name string) *errors.Error {
+func (c *Client) EnableRepository(ctx context.Context, user, name string) error {
 	_, err := c.client.EnableRepository(ctx, &data.RepoUserSelection{Username: user, RepoName: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
@@ -63,7 +63,7 @@ func (c *Client) EnableRepository(ctx context.Context, user, name string) *error
 }
 
 // DisableRepository disabls a repository in CI for a user as owner.
-func (c *Client) DisableRepository(ctx context.Context, user, name string) *errors.Error {
+func (c *Client) DisableRepository(ctx context.Context, user, name string) error {
 	_, err := c.client.DisableRepository(ctx, &data.RepoUserSelection{Username: user, RepoName: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
@@ -73,7 +73,7 @@ func (c *Client) DisableRepository(ctx context.Context, user, name string) *erro
 }
 
 // OwnedRepositories lists the owned repositories by the user.
-func (c *Client) OwnedRepositories(ctx context.Context, name, search string) (model.RepositoryList, *errors.Error) {
+func (c *Client) OwnedRepositories(ctx context.Context, name, search string) (model.RepositoryList, error) {
 	list, err := c.client.OwnedRepositories(ctx, &data.NameSearch{Name: name, Search: search}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -83,7 +83,7 @@ func (c *Client) OwnedRepositories(ctx context.Context, name, search string) (mo
 }
 
 // AllRepositories lists all visible repositories by the user.
-func (c *Client) AllRepositories(ctx context.Context, name, search string) (model.RepositoryList, *errors.Error) {
+func (c *Client) AllRepositories(ctx context.Context, name, search string) (model.RepositoryList, error) {
 	list, err := c.client.AllRepositories(ctx, &data.NameSearch{Name: name, Search: search}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -93,7 +93,7 @@ func (c *Client) AllRepositories(ctx context.Context, name, search string) (mode
 }
 
 // PrivateRepositories lists all visible private repositories by the user.
-func (c *Client) PrivateRepositories(ctx context.Context, name, search string) (model.RepositoryList, *errors.Error) {
+func (c *Client) PrivateRepositories(ctx context.Context, name, search string) (model.RepositoryList, error) {
 	list, err := c.client.PrivateRepositories(ctx, &data.NameSearch{Name: name, Search: search}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -103,7 +103,7 @@ func (c *Client) PrivateRepositories(ctx context.Context, name, search string) (
 }
 
 // PublicRepositories lists all owned public repositories by the user.
-func (c *Client) PublicRepositories(ctx context.Context, search string) (model.RepositoryList, *errors.Error) {
+func (c *Client) PublicRepositories(ctx context.Context, search string) (model.RepositoryList, error) {
 	list, err := c.client.PublicRepositories(ctx, &data.Search{Search: search}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)

--- a/clients/data/run.go
+++ b/clients/data/run.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RunCount returns the count of all items that match the repoName and sha.
-func (c *Client) RunCount(ctx context.Context, repoName, sha string) (int64, *errors.Error) {
+func (c *Client) RunCount(ctx context.Context, repoName, sha string) (int64, error) {
 	count, err := c.client.RunCount(ctx, &data.RefPair{RepoName: repoName, Sha: sha}, grpc.WaitForReady(true))
 	if err != nil {
 		return 0, errors.New(err)
@@ -21,7 +21,7 @@ func (c *Client) RunCount(ctx context.Context, repoName, sha string) (int64, *er
 }
 
 // ListRuns lists runs by repository name and sha
-func (c *Client) ListRuns(ctx context.Context, repoName, sha string, page, perPage int64) ([]*model.Run, *errors.Error) {
+func (c *Client) ListRuns(ctx context.Context, repoName, sha string, page, perPage int64) ([]*model.Run, error) {
 	list, err := c.client.RunList(ctx, &data.RunListRequest{Repository: repoName, Sha: sha, Page: page, PerPage: perPage}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -42,7 +42,7 @@ func (c *Client) ListRuns(ctx context.Context, repoName, sha string, page, perPa
 }
 
 // GetRun retrieves a run by id.
-func (c *Client) GetRun(ctx context.Context, id int64) (*model.Run, *errors.Error) {
+func (c *Client) GetRun(ctx context.Context, id int64) (*model.Run, error) {
 	run, err := c.client.GetRun(ctx, &types.IntID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -52,7 +52,7 @@ func (c *Client) GetRun(ctx context.Context, id int64) (*model.Run, *errors.Erro
 }
 
 // GetRunUI retrieves a run by id.
-func (c *Client) GetRunUI(ctx context.Context, id int64) (*model.Run, *errors.Error) {
+func (c *Client) GetRunUI(ctx context.Context, id int64) (*model.Run, error) {
 	run, err := c.client.GetRunUI(ctx, &types.IntID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)

--- a/clients/data/session.go
+++ b/clients/data/session.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GetSession retrieves a session from the database by id.
-func (c *Client) GetSession(ctx context.Context, id string) (*model.Session, *errors.Error) {
+func (c *Client) GetSession(ctx context.Context, id string) (*model.Session, error) {
 	s, err := c.client.LoadSession(ctx, &types.StringID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -20,7 +20,7 @@ func (c *Client) GetSession(ctx context.Context, id string) (*model.Session, *er
 }
 
 // PutSession adds a session to the database.
-func (c *Client) PutSession(ctx context.Context, s *model.Session) *errors.Error {
+func (c *Client) PutSession(ctx context.Context, s *model.Session) error {
 	_, err := c.client.PutSession(ctx, s.ToProto(), grpc.WaitForReady(true))
 	return errors.New(err)
 }

--- a/clients/data/submission.go
+++ b/clients/data/submission.go
@@ -10,7 +10,7 @@ import (
 )
 
 // PutSubmission puts a submission into the datasvc. Updates the created_at time.
-func (c *Client) PutSubmission(ctx context.Context, sub *model.Submission) (*model.Submission, *errors.Error) {
+func (c *Client) PutSubmission(ctx context.Context, sub *model.Submission) (*model.Submission, error) {
 	s, err := c.client.PutSubmission(ctx, sub.ToProto())
 	if err != nil {
 		return nil, errors.New(err)
@@ -20,7 +20,7 @@ func (c *Client) PutSubmission(ctx context.Context, sub *model.Submission) (*mod
 }
 
 // GetSubmissionByID returns the submission for the given ID.
-func (c *Client) GetSubmissionByID(ctx context.Context, id int64) (*model.Submission, *errors.Error) {
+func (c *Client) GetSubmissionByID(ctx context.Context, id int64) (*model.Submission, error) {
 	s, err := c.client.GetSubmission(ctx, &types.IntID{ID: id})
 	if err != nil {
 		return nil, errors.New(err)
@@ -30,7 +30,7 @@ func (c *Client) GetSubmissionByID(ctx context.Context, id int64) (*model.Submis
 }
 
 // GetRunsForSubmission returns the runs for the given submission; with pagination
-func (c *Client) GetRunsForSubmission(ctx context.Context, sub *model.Submission, page, perPage int64) ([]*model.Run, *errors.Error) {
+func (c *Client) GetRunsForSubmission(ctx context.Context, sub *model.Submission, page, perPage int64) ([]*model.Run, error) {
 	runs, err := c.client.GetSubmissionRuns(ctx, &data.SubmissionQuery{Submission: sub.ToProto(), Page: page, PerPage: perPage})
 	if err != nil {
 		return nil, errors.New(err)
@@ -50,7 +50,7 @@ func (c *Client) GetRunsForSubmission(ctx context.Context, sub *model.Submission
 }
 
 // GetTasksForSubmission returns the tasks for the given submission; with pagination
-func (c *Client) GetTasksForSubmission(ctx context.Context, sub *model.Submission, page, perPage int64) ([]*model.Task, *errors.Error) {
+func (c *Client) GetTasksForSubmission(ctx context.Context, sub *model.Submission, page, perPage int64) ([]*model.Task, error) {
 	tasks, err := c.client.GetSubmissionTasks(ctx, &data.SubmissionQuery{Submission: sub.ToProto(), Page: page, PerPage: perPage})
 	if err != nil {
 		return nil, errors.New(err)
@@ -71,7 +71,7 @@ func (c *Client) GetTasksForSubmission(ctx context.Context, sub *model.Submissio
 
 // ListSubmissions lists the submissions with pagination, and an optional (just
 // pass empty strings if undesired) repository and sha filter.
-func (c *Client) ListSubmissions(ctx context.Context, page, perPage int64, repository, sha string) ([]*model.Submission, *errors.Error) {
+func (c *Client) ListSubmissions(ctx context.Context, page, perPage int64, repository, sha string) ([]*model.Submission, error) {
 	list, err := c.client.ListSubmissions(ctx, &data.RepositoryFilterRequestWithPagination{Page: page, PerPage: perPage, Repository: repository, Sha: sha})
 	if err != nil {
 		return nil, errors.New(err)
@@ -93,7 +93,7 @@ func (c *Client) ListSubmissions(ctx context.Context, page, perPage int64, repos
 
 // CountSubmissions returns the count of all submissions that meet the optional
 // filtering requirements.
-func (c *Client) CountSubmissions(ctx context.Context, repository, sha string) (int64, *errors.Error) {
+func (c *Client) CountSubmissions(ctx context.Context, repository, sha string) (int64, error) {
 	count, err := c.client.CountSubmissions(ctx, &data.RepositoryFilterRequest{Repository: repository, Sha: sha})
 	if err != nil {
 		return 0, errors.New(err)
@@ -103,7 +103,7 @@ func (c *Client) CountSubmissions(ctx context.Context, repository, sha string) (
 }
 
 // CancelSubmission cancels a submission by ID.
-func (c *Client) CancelSubmission(ctx context.Context, id int64) *errors.Error {
+func (c *Client) CancelSubmission(ctx context.Context, id int64) error {
 	if _, err := c.client.CancelSubmission(ctx, &types.IntID{ID: id}); err != nil {
 		return errors.New(err)
 	}

--- a/clients/data/subscriptions.go
+++ b/clients/data/subscriptions.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ListSubscriptions lists the subscriptions that the user has selected.
-func (c *Client) ListSubscriptions(ctx context.Context, name, search string) (model.RepositoryList, *errors.Error) {
+func (c *Client) ListSubscriptions(ctx context.Context, name, search string) (model.RepositoryList, error) {
 	rl, err := c.client.ListSubscriptions(ctx, &data.NameSearch{Name: name, Search: search}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -20,7 +20,7 @@ func (c *Client) ListSubscriptions(ctx context.Context, name, search string) (mo
 }
 
 // AddSubscription adds a subscription for the user.
-func (c *Client) AddSubscription(ctx context.Context, name, repo string) *errors.Error {
+func (c *Client) AddSubscription(ctx context.Context, name, repo string) error {
 	_, err := c.client.AddSubscription(ctx, &data.RepoUserSelection{RepoName: repo, Username: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
@@ -30,7 +30,7 @@ func (c *Client) AddSubscription(ctx context.Context, name, repo string) *errors
 }
 
 // DeleteSubscription removes a subscription for the user.
-func (c *Client) DeleteSubscription(ctx context.Context, name, repo string) *errors.Error {
+func (c *Client) DeleteSubscription(ctx context.Context, name, repo string) error {
 	// sigh.. these names.
 	_, err := c.client.RemoveSubscription(ctx, &data.RepoUserSelection{RepoName: repo, Username: name}, grpc.WaitForReady(true))
 	if err != nil {

--- a/clients/data/task.go
+++ b/clients/data/task.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CancelTasksByPR cancels tasks by PR ID.
-func (c *Client) CancelTasksByPR(ctx context.Context, repository string, prID int64) *errors.Error {
+func (c *Client) CancelTasksByPR(ctx context.Context, repository string, prID int64) error {
 	if _, err := c.client.CancelTasksByPR(ctx, &types.CancelPRRequest{Repository: repository, Id: prID}, grpc.WaitForReady(true)); err != nil {
 		return errors.New(err)
 	}
@@ -20,7 +20,7 @@ func (c *Client) CancelTasksByPR(ctx context.Context, repository string, prID in
 }
 
 // PutTask adds a task to the database.
-func (c *Client) PutTask(ctx context.Context, task *model.Task) (*model.Task, *errors.Error) {
+func (c *Client) PutTask(ctx context.Context, task *model.Task) (*model.Task, error) {
 	t, err := c.client.PutTask(ctx, task.ToProto(), grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -32,7 +32,7 @@ func (c *Client) PutTask(ctx context.Context, task *model.Task) (*model.Task, *e
 // ListTasks returns the items in the task list that match the repository and
 // sha parameters; they may also be blank to select all items. page and perPage
 // are limiters to define pagination rules.
-func (c *Client) ListTasks(ctx context.Context, repository, sha string, page, perPage int64) ([]*model.Task, *errors.Error) {
+func (c *Client) ListTasks(ctx context.Context, repository, sha string, page, perPage int64) ([]*model.Task, error) {
 	tasks, err := c.client.ListTasks(ctx, &data.TaskListRequest{
 		Repository: repository,
 		Sha:        sha,
@@ -58,7 +58,7 @@ func (c *Client) ListTasks(ctx context.Context, repository, sha string, page, pe
 }
 
 // CountTasks counts the tasks with the filters applied.
-func (c *Client) CountTasks(ctx context.Context, repository, sha string) (int64, *errors.Error) {
+func (c *Client) CountTasks(ctx context.Context, repository, sha string) (int64, error) {
 	count, err := c.client.CountTasks(ctx, &data.TaskListRequest{Repository: repository, Sha: sha}, grpc.WaitForReady(true))
 	if err != nil {
 		return 0, errors.New(err)
@@ -68,7 +68,7 @@ func (c *Client) CountTasks(ctx context.Context, repository, sha string) (int64,
 }
 
 // GetRunsForTask retrieves all the runs by task ID.
-func (c *Client) GetRunsForTask(ctx context.Context, taskID, page, perPage int64) ([]*model.Run, *errors.Error) {
+func (c *Client) GetRunsForTask(ctx context.Context, taskID, page, perPage int64) ([]*model.Run, error) {
 	runs, err := c.client.RunsForTask(ctx, &data.RunsForTaskRequest{Id: taskID, Page: page, PerPage: perPage}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -89,7 +89,7 @@ func (c *Client) GetRunsForTask(ctx context.Context, taskID, page, perPage int64
 }
 
 // CountRunsForTask counts all the runs associated with the task.
-func (c *Client) CountRunsForTask(ctx context.Context, taskID int64) (int64, *errors.Error) {
+func (c *Client) CountRunsForTask(ctx context.Context, taskID int64) (int64, error) {
 	count, err := c.client.CountRunsForTask(ctx, &types.IntID{ID: taskID}, grpc.WaitForReady(true))
 	if err != nil {
 		return 0, errors.New(err)
@@ -99,7 +99,7 @@ func (c *Client) CountRunsForTask(ctx context.Context, taskID int64) (int64, *er
 }
 
 // ListSubscribedTasksForUser lists all the tasks for the repos the user is subscribed to.
-func (c *Client) ListSubscribedTasksForUser(ctx context.Context, userID, page, perPage int64) ([]*model.Task, *errors.Error) {
+func (c *Client) ListSubscribedTasksForUser(ctx context.Context, userID, page, perPage int64) ([]*model.Task, error) {
 	modelTasks := []*model.Task{}
 
 	tasks, err := c.client.ListSubscribedTasksForUser(ctx, &data.ListSubscribedTasksRequest{Id: userID, Page: page, PerPage: perPage}, grpc.WaitForReady(true))
@@ -120,7 +120,7 @@ func (c *Client) ListSubscribedTasksForUser(ctx context.Context, userID, page, p
 }
 
 // CancelTask cancels a task by id.
-func (c *Client) CancelTask(ctx context.Context, id int64) *errors.Error {
+func (c *Client) CancelTask(ctx context.Context, id int64) error {
 	_, err := c.client.CancelTask(ctx, &types.IntID{ID: id})
 	return errors.New(err)
 }

--- a/clients/data/token.go
+++ b/clients/data/token.go
@@ -13,7 +13,7 @@ import (
 // GetToken returns a newly minted access token to tinyCI or error otherwise.
 // To get a new token with this method, call the DeleteToken method first if
 // one exists already.
-func (c *Client) GetToken(ctx context.Context, username string) (string, *errors.Error) {
+func (c *Client) GetToken(ctx context.Context, username string) (string, error) {
 	token, err := c.client.GetToken(ctx, &data.Name{Name: username}, grpc.WaitForReady(true))
 	if err != nil {
 		return "", errors.New(err)
@@ -24,7 +24,7 @@ func (c *Client) GetToken(ctx context.Context, username string) (string, *errors
 
 // DeleteToken removes the existing access token and makes it available to be
 // regenerated.
-func (c *Client) DeleteToken(ctx context.Context, username string) *errors.Error {
+func (c *Client) DeleteToken(ctx context.Context, username string) error {
 	_, err := c.client.DeleteToken(ctx, &data.Name{Name: username}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
@@ -33,7 +33,7 @@ func (c *Client) DeleteToken(ctx context.Context, username string) *errors.Error
 }
 
 // ValidateToken validates the token and returns error if it is not valid somehow.
-func (c *Client) ValidateToken(ctx context.Context, token string) (*model.User, *errors.Error) {
+func (c *Client) ValidateToken(ctx context.Context, token string) (*model.User, error) {
 	user, err := c.client.ValidateToken(ctx, &types.StringID{ID: token}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)

--- a/clients/data/user.go
+++ b/clients/data/user.go
@@ -11,7 +11,7 @@ import (
 )
 
 // PatchUser adjusts the token for the user.
-func (c *Client) PatchUser(ctx context.Context, u *model.User) *errors.Error {
+func (c *Client) PatchUser(ctx context.Context, u *model.User) error {
 	_, err := c.client.PatchUser(ctx, u.ToProto(), grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
@@ -21,7 +21,7 @@ func (c *Client) PatchUser(ctx context.Context, u *model.User) *errors.Error {
 }
 
 // PutUser inserts the user provided.
-func (c *Client) PutUser(ctx context.Context, u *model.User) (*model.User, *errors.Error) {
+func (c *Client) PutUser(ctx context.Context, u *model.User) (*model.User, error) {
 	u2, err := c.client.PutUser(ctx, u.ToProto(), grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -31,7 +31,7 @@ func (c *Client) PutUser(ctx context.Context, u *model.User) (*model.User, *erro
 }
 
 // GetUser obtains a user record by name
-func (c *Client) GetUser(ctx context.Context, name string) (*model.User, *errors.Error) {
+func (c *Client) GetUser(ctx context.Context, name string) (*model.User, error) {
 	u, err := c.client.UserByName(ctx, &data.Name{Name: name}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -41,7 +41,7 @@ func (c *Client) GetUser(ctx context.Context, name string) (*model.User, *errors
 }
 
 // ListUsers lists the users in the system.
-func (c *Client) ListUsers(ctx context.Context) ([]*model.User, *errors.Error) {
+func (c *Client) ListUsers(ctx context.Context) ([]*model.User, error) {
 	users, err := c.client.ListUsers(ctx, &empty.Empty{}, grpc.WaitForReady(true))
 	if err != nil {
 		return nil, errors.New(err)
@@ -62,7 +62,7 @@ func (c *Client) ListUsers(ctx context.Context) ([]*model.User, *errors.Error) {
 }
 
 // GetCapabilities yields the capabilities that belong to the user.
-func (c *Client) GetCapabilities(ctx context.Context, u *model.User) ([]model.Capability, *errors.Error) {
+func (c *Client) GetCapabilities(ctx context.Context, u *model.User) ([]model.Capability, error) {
 	caps, err := c.client.GetCapabilities(ctx, u.ToProto())
 	if err != nil {
 		return nil, errors.New(err)
@@ -77,7 +77,7 @@ func (c *Client) GetCapabilities(ctx context.Context, u *model.User) ([]model.Ca
 }
 
 // HasCapability returns true if the user has the specified capability.
-func (c *Client) HasCapability(ctx context.Context, u *model.User, cap model.Capability) (bool, *errors.Error) {
+func (c *Client) HasCapability(ctx context.Context, u *model.User, cap model.Capability) (bool, error) {
 	res, err := c.client.HasCapability(ctx, &data.CapabilityRequest{Id: u.ID, Capability: string(cap)}, grpc.WaitForReady(true))
 	if err != nil {
 		return false, errors.New(err)
@@ -87,7 +87,7 @@ func (c *Client) HasCapability(ctx context.Context, u *model.User, cap model.Cap
 }
 
 // AddCapability adds a capability for a user.
-func (c *Client) AddCapability(ctx context.Context, u *model.User, cap model.Capability) *errors.Error {
+func (c *Client) AddCapability(ctx context.Context, u *model.User, cap model.Capability) error {
 	_, err := c.client.AddCapability(ctx, &data.CapabilityRequest{Id: u.ID, Capability: string(cap)}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
@@ -97,7 +97,7 @@ func (c *Client) AddCapability(ctx context.Context, u *model.User, cap model.Cap
 }
 
 // RemoveCapability removes a capability from a user.
-func (c *Client) RemoveCapability(ctx context.Context, u *model.User, cap model.Capability) *errors.Error {
+func (c *Client) RemoveCapability(ctx context.Context, u *model.User, cap model.Capability) error {
 	_, err := c.client.RemoveCapability(ctx, &data.CapabilityRequest{Id: u.ID, Capability: string(cap)}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)

--- a/clients/github/github.go
+++ b/clients/github/github.go
@@ -24,22 +24,22 @@ var (
 
 // Client is the generic client to github operations.
 type Client interface {
-	CommentError(context.Context, string, int64, *errors.Error) *errors.Error
-	MyRepositories(context.Context) ([]*github.Repository, *errors.Error)
-	GetRepository(context.Context, string) (*github.Repository, *errors.Error)
-	MyLogin(context.Context) (string, *errors.Error)
-	GetFileList(context.Context, string, string) ([]string, *errors.Error)
-	GetSHA(context.Context, string, string) (string, *errors.Error)
-	GetRefs(context.Context, string, string) ([]string, *errors.Error)
-	GetFile(context.Context, string, string, string) ([]byte, *errors.Error)
-	GetDiffFiles(context.Context, string, string, string) ([]string, *errors.Error)
-	SetupHook(context.Context, string, string, string, string) *errors.Error
-	TeardownHook(context.Context, string, string, string) *errors.Error
-	PendingStatus(context.Context, string, string, string, string, string) *errors.Error
-	StartedStatus(context.Context, string, string, string, string, string) *errors.Error
-	ErrorStatus(context.Context, string, string, string, string, string, *errors.Error) *errors.Error
-	FinishedStatus(context.Context, string, string, string, string, string, bool, string) *errors.Error
-	ClearStates(context.Context, string, string) *errors.Error
+	CommentError(context.Context, string, int64, error) error
+	MyRepositories(context.Context) ([]*github.Repository, error)
+	GetRepository(context.Context, string) (*github.Repository, error)
+	MyLogin(context.Context) (string, error)
+	GetFileList(context.Context, string, string) ([]string, error)
+	GetSHA(context.Context, string, string) (string, error)
+	GetRefs(context.Context, string, string) ([]string, error)
+	GetFile(context.Context, string, string, string) ([]byte, error)
+	GetDiffFiles(context.Context, string, string, string) ([]string, error)
+	SetupHook(context.Context, string, string, string, string) error
+	TeardownHook(context.Context, string, string, string) error
+	PendingStatus(context.Context, string, string, string, string, string) error
+	StartedStatus(context.Context, string, string, string, string, string) error
+	ErrorStatus(context.Context, string, string, string, string, string, error) error
+	FinishedStatus(context.Context, string, string, string, string, string, bool, string) error
+	ClearStates(context.Context, string, string) error
 }
 
 // HTTPClient encapsulates the "real world", or http client.
@@ -59,7 +59,7 @@ func NewClientFromAccessToken(accessToken string) Client {
 }
 
 // PendingStatus updates the status for the sha for the given repo on github.
-func (c *HTTPClient) PendingStatus(ctx context.Context, owner, repo, name, sha, url string) *errors.Error {
+func (c *HTTPClient) PendingStatus(ctx context.Context, owner, repo, name, sha, url string) error {
 	if Readonly {
 		return nil
 	}
@@ -75,7 +75,7 @@ func (c *HTTPClient) PendingStatus(ctx context.Context, owner, repo, name, sha, 
 }
 
 // StartedStatus updates the status for the sha for the given repo on github.
-func (c *HTTPClient) StartedStatus(ctx context.Context, owner, repo, name, sha, url string) *errors.Error {
+func (c *HTTPClient) StartedStatus(ctx context.Context, owner, repo, name, sha, url string) error {
 	if Readonly {
 		return nil
 	}
@@ -99,7 +99,7 @@ func capStatus(str string) *string {
 }
 
 // ErrorStatus updates the status for the sha for the given repo on github.
-func (c *HTTPClient) ErrorStatus(ctx context.Context, owner, repo, name, sha, url string, outErr *errors.Error) *errors.Error {
+func (c *HTTPClient) ErrorStatus(ctx context.Context, owner, repo, name, sha, url string, outErr error) error {
 	if Readonly {
 		return nil
 	}
@@ -108,7 +108,7 @@ func (c *HTTPClient) ErrorStatus(ctx context.Context, owner, repo, name, sha, ur
 		TargetURL: github.String(url),
 		State:     github.String("error"),
 		// github statuses cap at 140c
-		Description: capStatus(errors.New(outErr).Wrap("The run encountered an error").Error()),
+		Description: capStatus(errors.New(outErr).(errors.Error).Wrap("The run encountered an error").Error()),
 		Context:     github.String(name),
 	})
 
@@ -116,7 +116,7 @@ func (c *HTTPClient) ErrorStatus(ctx context.Context, owner, repo, name, sha, ur
 }
 
 // FinishedStatus updates the status for the sha for the given repo on github.
-func (c *HTTPClient) FinishedStatus(ctx context.Context, owner, repo, name, sha, url string, status bool, addlMessage string) *errors.Error {
+func (c *HTTPClient) FinishedStatus(ctx context.Context, owner, repo, name, sha, url string, status bool, addlMessage string) error {
 	if Readonly {
 		return nil
 	}
@@ -138,7 +138,7 @@ func (c *HTTPClient) FinishedStatus(ctx context.Context, owner, repo, name, sha,
 }
 
 // SetupHook sets up the pr webhook in github.
-func (c *HTTPClient) SetupHook(ctx context.Context, owner, repo, configAddress, hookSecret string) *errors.Error {
+func (c *HTTPClient) SetupHook(ctx context.Context, owner, repo, configAddress, hookSecret string) error {
 	if Readonly {
 		return nil
 	}
@@ -158,7 +158,7 @@ func (c *HTTPClient) SetupHook(ctx context.Context, owner, repo, configAddress, 
 }
 
 // TeardownHook removes the pr webhook in github.
-func (c *HTTPClient) TeardownHook(ctx context.Context, owner, repo, hookURL string) *errors.Error {
+func (c *HTTPClient) TeardownHook(ctx context.Context, owner, repo, hookURL string) error {
 	if Readonly {
 		return nil
 	}
@@ -191,7 +191,7 @@ finish:
 
 // MyRepositories returns all the writable repositories accessible to user
 // owning the access key
-func (c *HTTPClient) MyRepositories(ctx context.Context) ([]*github.Repository, *errors.Error) {
+func (c *HTTPClient) MyRepositories(ctx context.Context) ([]*github.Repository, error) {
 	var i int
 	ret := map[string]*github.Repository{}
 	order := []string{}
@@ -239,7 +239,7 @@ func (c *HTTPClient) MyRepositories(ctx context.Context) ([]*github.Repository, 
 
 // MyLogin returns the username calling out to the API with its key. Can either
 // be seeded by OAuth or Personal Token.
-func (c *HTTPClient) MyLogin(ctx context.Context) (string, *errors.Error) {
+func (c *HTTPClient) MyLogin(ctx context.Context) (string, error) {
 	if DefaultUsername != "" {
 		return DefaultUsername, nil
 	}
@@ -253,7 +253,7 @@ func (c *HTTPClient) MyLogin(ctx context.Context) (string, *errors.Error) {
 }
 
 // GetRepository retrieves the github response for a given repository.
-func (c *HTTPClient) GetRepository(ctx context.Context, name string) (*github.Repository, *errors.Error) {
+func (c *HTTPClient) GetRepository(ctx context.Context, name string) (*github.Repository, error) {
 	owner, repo, eErr := utils.OwnerRepo(name)
 	if eErr != nil {
 		return nil, eErr
@@ -264,7 +264,7 @@ func (c *HTTPClient) GetRepository(ctx context.Context, name string) (*github.Re
 }
 
 // GetFileList finds all the files in the tree for the given repository
-func (c *HTTPClient) GetFileList(ctx context.Context, repoName, sha string) ([]string, *errors.Error) {
+func (c *HTTPClient) GetFileList(ctx context.Context, repoName, sha string) ([]string, error) {
 	owner, repo, eErr := utils.OwnerRepo(repoName)
 	if eErr != nil {
 		return nil, eErr
@@ -285,7 +285,7 @@ func (c *HTTPClient) GetFileList(ctx context.Context, repoName, sha string) ([]s
 }
 
 // GetSHA retrieves the SHA for the branch in the given repository
-func (c *HTTPClient) GetSHA(ctx context.Context, repoName, refName string) (string, *errors.Error) {
+func (c *HTTPClient) GetSHA(ctx context.Context, repoName, refName string) (string, error) {
 	owner, repo, eErr := utils.OwnerRepo(repoName)
 	if eErr != nil {
 		return "", eErr
@@ -300,7 +300,7 @@ func (c *HTTPClient) GetSHA(ctx context.Context, repoName, refName string) (stri
 }
 
 // GetRefs gets the refs that match the given SHA. Only heads and tags are considered.
-func (c *HTTPClient) GetRefs(ctx context.Context, repoName, sha string) ([]string, *errors.Error) {
+func (c *HTTPClient) GetRefs(ctx context.Context, repoName, sha string) ([]string, error) {
 	owner, repo, eErr := utils.OwnerRepo(repoName)
 	if eErr != nil {
 		return nil, eErr
@@ -325,7 +325,7 @@ func (c *HTTPClient) GetRefs(ctx context.Context, repoName, sha string) ([]strin
 
 // GetFile retrieves a file from github directly through the api. Used for
 // retrieving our configuration yamls and other stuff.
-func (c *HTTPClient) GetFile(ctx context.Context, repoName, sha, filename string) ([]byte, *errors.Error) {
+func (c *HTTPClient) GetFile(ctx context.Context, repoName, sha, filename string) ([]byte, error) {
 	owner, repo, eErr := utils.OwnerRepo(repoName)
 	if eErr != nil {
 		return nil, eErr
@@ -351,7 +351,7 @@ func (c *HTTPClient) GetFile(ctx context.Context, repoName, sha, filename string
 }
 
 // GetDiffFiles retrieves the files present in the diff between the base and the head.
-func (c *HTTPClient) GetDiffFiles(ctx context.Context, repoName, base, head string) ([]string, *errors.Error) {
+func (c *HTTPClient) GetDiffFiles(ctx context.Context, repoName, base, head string) ([]string, error) {
 	owner, repo, eErr := utils.OwnerRepo(repoName)
 	if eErr != nil {
 		return nil, eErr
@@ -381,7 +381,7 @@ func (c *HTTPClient) GetDiffFiles(ctx context.Context, repoName, base, head stri
 
 // ClearStates removes all status reports from a SHA in an attempt to restart
 // the process.
-func (c *HTTPClient) ClearStates(ctx context.Context, repoName, sha string) *errors.Error {
+func (c *HTTPClient) ClearStates(ctx context.Context, repoName, sha string) error {
 	if Readonly {
 		return nil
 	}
@@ -430,7 +430,7 @@ func (c *HTTPClient) ClearStates(ctx context.Context, repoName, sha string) *err
 }
 
 // CommentError is for commenting on PRs when there is no better means of bubbling up an error.
-func (c *HTTPClient) CommentError(ctx context.Context, repoName string, prID int64, err *errors.Error) *errors.Error {
+func (c *HTTPClient) CommentError(ctx context.Context, repoName string, prID int64, err error) error {
 	if Readonly {
 		return nil
 	}

--- a/clients/jsonbuffer/jsonbuffer.go
+++ b/clients/jsonbuffer/jsonbuffer.go
@@ -48,7 +48,7 @@ func NewWrapper(rw io.ReadWriter) *Wrapper {
 
 // Send sends a message by writing through the Wrapper. The outgoing message will be of
 // type websocket.TypeMessage.
-func (w *Wrapper) Send(message string) *errors.Error {
+func (w *Wrapper) Send(message string) error {
 	if err := w.enc.Encode(Message{Type: TypeMessage, Payload: message}); err != nil {
 		return errors.New(err)
 	}
@@ -57,7 +57,7 @@ func (w *Wrapper) Send(message string) *errors.Error {
 }
 
 // SendError is like Send, but for errors.
-func (w *Wrapper) SendError(err error) *errors.Error {
+func (w *Wrapper) SendError(err error) error {
 	return errors.New(w.enc.Encode(Message{Type: TypeError, Payload: err.Error()}))
 }
 

--- a/clients/log/log.go
+++ b/clients/log/log.go
@@ -103,14 +103,14 @@ func (f *Fields) ToLogrus() map[string]interface{} {
 }
 
 // ConfigureRemote configures the remote endpoint with a provided URL.
-func ConfigureRemote(addr string, cert *transport.Cert, trace bool) *errors.Error {
+func ConfigureRemote(addr string, cert *transport.Cert, trace bool) error {
 	remoteMutex.Lock()
 	defer remoteMutex.Unlock()
 
 	var (
 		closer  io.Closer
 		options []grpc.DialOption
-		eErr    *errors.Error
+		eErr    error
 	)
 
 	if trace {
@@ -262,7 +262,7 @@ func (sub *SubLogger) Log(ctx context.Context, level string, msg interface{}, lo
 	}
 
 	switch msg := msg.(type) {
-	case *errors.Error:
+	case errors.Error:
 		if msg.Log {
 			localLog(msg)
 		}

--- a/clients/queue/client.go
+++ b/clients/queue/client.go
@@ -20,11 +20,11 @@ type Client struct {
 }
 
 // New constructs a new *Client.
-func New(addr string, cert *transport.Cert, trace bool) (*Client, *errors.Error) {
+func New(addr string, cert *transport.Cert, trace bool) (*Client, error) {
 	var (
 		closer  io.Closer
 		options []grpc.DialOption
-		eErr    *errors.Error
+		eErr    error
 	)
 
 	if trace {
@@ -52,7 +52,7 @@ func (c *Client) Close() error {
 }
 
 // GetCancel retrieves the cancel state of the run.
-func (c *Client) GetCancel(ctx context.Context, id int64) (bool, *errors.Error) {
+func (c *Client) GetCancel(ctx context.Context, id int64) (bool, error) {
 	status, err := c.client.GetCancel(ctx, &types.IntID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return false, errors.New(err)
@@ -62,7 +62,7 @@ func (c *Client) GetCancel(ctx context.Context, id int64) (bool, *errors.Error) 
 }
 
 // SetCancel sets the cancel state for a given run id.
-func (c *Client) SetCancel(ctx context.Context, id int64) *errors.Error {
+func (c *Client) SetCancel(ctx context.Context, id int64) error {
 	_, err := c.client.SetCancel(ctx, &types.IntID{ID: id}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)
@@ -72,7 +72,7 @@ func (c *Client) SetCancel(ctx context.Context, id int64) *errors.Error {
 }
 
 // NextQueueItem returns the next item in the queue.
-func (c *Client) NextQueueItem(ctx context.Context, queueName, hostname string) (*model.QueueItem, *errors.Error) {
+func (c *Client) NextQueueItem(ctx context.Context, queueName, hostname string) (*model.QueueItem, error) {
 	qi, err := c.client.NextQueueItem(ctx, &types.QueueRequest{QueueName: queueName, RunningOn: hostname}, grpc.WaitForReady(false))
 	if err != nil {
 		return nil, errors.New(err)
@@ -82,7 +82,7 @@ func (c *Client) NextQueueItem(ctx context.Context, queueName, hostname string) 
 }
 
 // SetStatus completes the run by returning its status back to the system.
-func (c *Client) SetStatus(ctx context.Context, id int64, status bool) *errors.Error {
+func (c *Client) SetStatus(ctx context.Context, id int64, status bool) error {
 	_, err := c.client.PutStatus(ctx, &types.Status{Id: id, Status: status}, grpc.WaitForReady(true))
 	if err != nil {
 		return errors.New(err)

--- a/clients/queue/submit.go
+++ b/clients/queue/submit.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Submit submits a push or pull request to the queue.
-func (c *Client) Submit(ctx context.Context, sub *types.Submission) *errors.Error {
+func (c *Client) Submit(ctx context.Context, sub *types.Submission) error {
 	_, err := c.client.Submit(ctx, &queue.Submission{
 		Headsha:     sub.HeadSHA,
 		Basesha:     sub.BaseSHA,

--- a/clients/repository/client.go
+++ b/clients/repository/client.go
@@ -17,11 +17,11 @@ type Client struct {
 }
 
 // New creates a new *Client.
-func New(addr string, cert *transport.Cert, trace bool) (*Client, *errors.Error) {
+func New(addr string, cert *transport.Cert, trace bool) (*Client, error) {
 	var (
 		closer  io.Closer
 		options []grpc.DialOption
-		eErr    *errors.Error
+		eErr    error
 	)
 
 	if trace {

--- a/clients/repository/git.go
+++ b/clients/repository/git.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetFileList finds all the files in the tree for the given repository
-func (c *Client) GetFileList(ctx context.Context, repoName, sha string) ([]string, *errors.Error) {
+func (c *Client) GetFileList(ctx context.Context, repoName, sha string) ([]string, error) {
 	list, err := c.client.GetFileList(ctx, &repository.RepoSHAPair{RepoName: repoName, Sha: sha})
 	if err != nil {
 		return nil, errors.New(err)
@@ -18,7 +18,7 @@ func (c *Client) GetFileList(ctx context.Context, repoName, sha string) ([]strin
 }
 
 // GetSHA retrieves the SHA for the provided ref and repository.
-func (c *Client) GetSHA(ctx context.Context, repoName, ref string) (string, *errors.Error) {
+func (c *Client) GetSHA(ctx context.Context, repoName, ref string) (string, error) {
 	sha, err := c.client.GetSHA(ctx, &repository.RepoRefPair{RepoName: repoName, RefName: ref})
 	if err != nil {
 		return "", errors.New(err)
@@ -28,7 +28,7 @@ func (c *Client) GetSHA(ctx context.Context, repoName, ref string) (string, *err
 }
 
 // GetRefs retreives many refs that have the corresponding SHA.
-func (c *Client) GetRefs(ctx context.Context, repoName, sha string) ([]string, *errors.Error) {
+func (c *Client) GetRefs(ctx context.Context, repoName, sha string) ([]string, error) {
 	refs, err := c.client.GetRefs(ctx, &repository.RepoSHAPair{RepoName: repoName, Sha: sha})
 	if err != nil {
 		return nil, errors.New(err)
@@ -38,7 +38,7 @@ func (c *Client) GetRefs(ctx context.Context, repoName, sha string) ([]string, *
 }
 
 // GetFile retrieves an entire file by way of the repoName, sha, and filename.
-func (c *Client) GetFile(ctx context.Context, repoName, sha, filename string) ([]byte, *errors.Error) {
+func (c *Client) GetFile(ctx context.Context, repoName, sha, filename string) ([]byte, error) {
 	byts, err := c.client.GetFile(ctx, &repository.FileRequest{RepoName: repoName, Sha: sha, Filename: filename})
 	if err != nil {
 		return nil, errors.New(err)
@@ -48,7 +48,7 @@ func (c *Client) GetFile(ctx context.Context, repoName, sha, filename string) ([
 }
 
 // GetDiffFiles retrieves the files present in the diff between the base and the head.
-func (c *Client) GetDiffFiles(ctx context.Context, repoName, base, head string) ([]string, *errors.Error) {
+func (c *Client) GetDiffFiles(ctx context.Context, repoName, base, head string) ([]string, error) {
 	files, err := c.client.GetDiffFiles(ctx, &repository.FileDiffRequest{RepoName: repoName, Base: base, Head: head})
 	if err != nil {
 		return nil, errors.New(err)

--- a/clients/repository/hook.go
+++ b/clients/repository/hook.go
@@ -8,7 +8,7 @@ import (
 )
 
 // SetupHook sets up the pr webhook in the backing repository service.
-func (c *Client) SetupHook(ctx context.Context, repoName, url, secret string) *errors.Error {
+func (c *Client) SetupHook(ctx context.Context, repoName, url, secret string) error {
 	_, err := c.client.SetupHook(ctx, &repository.HookSetupRequest{RepoName: repoName, HookURL: url, HookSecret: secret})
 	if err != nil {
 		return errors.New(err)
@@ -18,7 +18,7 @@ func (c *Client) SetupHook(ctx context.Context, repoName, url, secret string) *e
 }
 
 // TeardownHook destroys the pr webhook in the backing repository service.
-func (c *Client) TeardownHook(ctx context.Context, repoName, url string) *errors.Error {
+func (c *Client) TeardownHook(ctx context.Context, repoName, url string) error {
 	_, err := c.client.TeardownHook(ctx, &repository.HookTeardownRequest{RepoName: repoName, HookURL: url})
 	if err != nil {
 		return errors.New(err)

--- a/clients/repository/repository.go
+++ b/clients/repository/repository.go
@@ -10,7 +10,7 @@ import (
 
 // MyRepositories returns all the writable repositories accessible to user
 // owning the access key
-func (c *Client) MyRepositories(ctx context.Context, u *model.User) ([]*repository.RepositoryData, *errors.Error) {
+func (c *Client) MyRepositories(ctx context.Context, u *model.User) ([]*repository.RepositoryData, error) {
 	list, err := c.client.MyRepositories(ctx, u.ToProto())
 	if err != nil {
 		return nil, errors.New(err)
@@ -20,7 +20,7 @@ func (c *Client) MyRepositories(ctx context.Context, u *model.User) ([]*reposito
 }
 
 // GetRepository retrieves the github response for a given repository.
-func (c *Client) GetRepository(ctx context.Context, u *model.User, repoName string) (*repository.RepositoryData, *errors.Error) {
+func (c *Client) GetRepository(ctx context.Context, u *model.User, repoName string) (*repository.RepositoryData, error) {
 	data, err := c.client.GetRepository(ctx, &repository.UserWithRepo{User: u.ToProto(), RepoName: repoName})
 	if err != nil {
 		return nil, errors.New(err)

--- a/clients/repository/status.go
+++ b/clients/repository/status.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CommentError is for commenting on PRs when there is no better means of bubbling up an error.
-func (c *Client) CommentError(ctx context.Context, repoName string, prID int64, errstr string) *errors.Error {
+func (c *Client) CommentError(ctx context.Context, repoName string, prID int64, errstr string) error {
 	_, err := c.client.CommentError(ctx, &repository.CommentErrorRequest{RepoName: repoName, PrID: prID, Error: errstr})
 	if err != nil {
 		return errors.New(err)
@@ -18,7 +18,7 @@ func (c *Client) CommentError(ctx context.Context, repoName string, prID int64, 
 }
 
 // PendingStatus updates the status for the sha for the given repo.
-func (c *Client) PendingStatus(ctx context.Context, repoName, sha, runName, url string) *errors.Error {
+func (c *Client) PendingStatus(ctx context.Context, repoName, sha, runName, url string) error {
 	_, err := c.client.PendingStatus(ctx, &repository.StatusRequest{RepoName: repoName, Sha: sha, RunName: runName, Url: url})
 	if err != nil {
 		return errors.New(err)
@@ -28,7 +28,7 @@ func (c *Client) PendingStatus(ctx context.Context, repoName, sha, runName, url 
 }
 
 // StartedStatus updates the status for the sha for the given repo.
-func (c *Client) StartedStatus(ctx context.Context, repoName, sha, runName, url string) *errors.Error {
+func (c *Client) StartedStatus(ctx context.Context, repoName, sha, runName, url string) error {
 	_, err := c.client.StartedStatus(ctx, &repository.StatusRequest{RepoName: repoName, Sha: sha, RunName: runName, Url: url})
 	if err != nil {
 		return errors.New(err)
@@ -38,7 +38,7 @@ func (c *Client) StartedStatus(ctx context.Context, repoName, sha, runName, url 
 }
 
 // ErrorStatus updates the status for the sha for the given repo.
-func (c *Client) ErrorStatus(ctx context.Context, repoName, sha, runName, url string, eErr error) *errors.Error {
+func (c *Client) ErrorStatus(ctx context.Context, repoName, sha, runName, url string, eErr error) error {
 	_, err := c.client.ErrorStatus(ctx, &repository.ErrorStatusRequest{
 		RepoName: repoName,
 		Sha:      sha,
@@ -54,7 +54,7 @@ func (c *Client) ErrorStatus(ctx context.Context, repoName, sha, runName, url st
 }
 
 // FinishedStatus updates the status for the sha for the given repo.
-func (c *Client) FinishedStatus(ctx context.Context, repoName, sha, runName, url string, status bool, msg string) *errors.Error {
+func (c *Client) FinishedStatus(ctx context.Context, repoName, sha, runName, url string, status bool, msg string) error {
 	_, err := c.client.FinishedStatus(ctx, &repository.FinishedStatusRequest{
 		RepoName: repoName,
 		Sha:      sha,
@@ -72,7 +72,7 @@ func (c *Client) FinishedStatus(ctx context.Context, repoName, sha, runName, url
 
 // ClearStates removes all status reports from a SHA in an attempt to restart
 // the process.
-func (c *Client) ClearStates(ctx context.Context, repoName, sha string) *errors.Error {
+func (c *Client) ClearStates(ctx context.Context, repoName, sha string) error {
 	_, err := c.client.ClearStates(ctx, &repository.RepoSHAPair{RepoName: repoName, Sha: sha})
 	if err != nil {
 		return errors.New(err)

--- a/clients/repository/user.go
+++ b/clients/repository/user.go
@@ -9,7 +9,7 @@ import (
 
 // MyLogin returns the username calling out to the API with its key. Can either
 // be seeded by OAuth or Personal Token.
-func (c *Client) MyLogin(ctx context.Context, token string) (string, *errors.Error) {
+func (c *Client) MyLogin(ctx context.Context, token string) (string, error) {
 	res, err := c.client.MyLogin(ctx, &repository.String{Name: token})
 	if err != nil {
 		return "", errors.New(err)

--- a/clients/tinyci/client.go
+++ b/clients/tinyci/client.go
@@ -6,7 +6,6 @@ import (
 
 	transport "github.com/erikh/go-transport"
 	"github.com/tinyci/ci-agents/ci-gen/gen/client/uisvc/client/operations"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/model"
 	"github.com/tinyci/ci-agents/utils"
 )
@@ -17,7 +16,7 @@ type Client struct {
 }
 
 // New constructs a new *Client
-func New(url, token string, cert *transport.Cert) (*Client, *errors.Error) {
+func New(url, token string, cert *transport.Cert) (*Client, error) {
 	c, err := operations.New(url, token, cert)
 	if err != nil {
 		return nil, err
@@ -27,12 +26,12 @@ func New(url, token string, cert *transport.Cert) (*Client, *errors.Error) {
 }
 
 // DeleteToken removes your token. You won't be able to request anything after making this call.
-func (c *Client) DeleteToken(ctx context.Context) *errors.Error {
+func (c *Client) DeleteToken(ctx context.Context) error {
 	return c.client.DeleteToken(ctx)
 }
 
 // Errors gets the user errors logged into the system.
-func (c *Client) Errors(ctx context.Context) ([]*model.UserError, *errors.Error) {
+func (c *Client) Errors(ctx context.Context) ([]*model.UserError, error) {
 	errs, err := c.client.GetErrors(ctx)
 	if err != nil {
 		return nil, err
@@ -44,18 +43,18 @@ func (c *Client) Errors(ctx context.Context) ([]*model.UserError, *errors.Error)
 }
 
 // Submit submits a request to test a repository to tinyCI.
-func (c *Client) Submit(ctx context.Context, repository, sha string, all bool) *errors.Error {
+func (c *Client) Submit(ctx context.Context, repository, sha string, all bool) error {
 	return c.client.GetSubmit(ctx, all, repository, sha)
 }
 
 // LogAttach attaches to a and retrieves it's output. Attach will block the
 // stream assuming that that job is not completed.
-func (c *Client) LogAttach(ctx context.Context, id int64, w io.WriteCloser) *errors.Error {
+func (c *Client) LogAttach(ctx context.Context, id int64, w io.WriteCloser) error {
 	return c.client.GetLogAttachID(ctx, id, w)
 }
 
 // LoadRepositories loads your repos from github and returns the objects tinyci recorded.
-func (c *Client) LoadRepositories(ctx context.Context, search string) ([]*model.Repository, *errors.Error) {
+func (c *Client) LoadRepositories(ctx context.Context, search string) ([]*model.Repository, error) {
 	if err := c.client.GetRepositoriesScan(ctx); err != nil {
 		return nil, err
 	}
@@ -75,7 +74,7 @@ func (c *Client) LoadRepositories(ctx context.Context, search string) ([]*model.
 }
 
 // AddToCI adds a repository to CI.
-func (c *Client) AddToCI(ctx context.Context, repository string) *errors.Error {
+func (c *Client) AddToCI(ctx context.Context, repository string) error {
 	owner, reponame, err := utils.OwnerRepo(repository)
 	if err != nil {
 		return err
@@ -85,7 +84,7 @@ func (c *Client) AddToCI(ctx context.Context, repository string) *errors.Error {
 }
 
 // DeleteFromCI deletes a repository from CI.
-func (c *Client) DeleteFromCI(ctx context.Context, repository string) *errors.Error {
+func (c *Client) DeleteFromCI(ctx context.Context, repository string) error {
 	owner, reponame, err := utils.OwnerRepo(repository)
 	if err != nil {
 		return err
@@ -94,7 +93,7 @@ func (c *Client) DeleteFromCI(ctx context.Context, repository string) *errors.Er
 }
 
 // Subscribed lists all subscribed repositories.
-func (c *Client) Subscribed(ctx context.Context, search string) ([]*model.Repository, *errors.Error) {
+func (c *Client) Subscribed(ctx context.Context, search string) ([]*model.Repository, error) {
 	repos, err := c.client.GetRepositoriesSubscribed(ctx, search)
 	if err != nil {
 		return nil, err
@@ -105,7 +104,7 @@ func (c *Client) Subscribed(ctx context.Context, search string) ([]*model.Reposi
 }
 
 // Visible lists all visible repositories.
-func (c *Client) Visible(ctx context.Context, search string) ([]*model.Repository, *errors.Error) {
+func (c *Client) Visible(ctx context.Context, search string) ([]*model.Repository, error) {
 	repos, err := c.client.GetRepositoriesVisible(ctx, search)
 	if err != nil {
 		return nil, err
@@ -116,7 +115,7 @@ func (c *Client) Visible(ctx context.Context, search string) ([]*model.Repositor
 }
 
 // Subscribe to a repository.
-func (c *Client) Subscribe(ctx context.Context, repository string) *errors.Error {
+func (c *Client) Subscribe(ctx context.Context, repository string) error {
 	owner, reponame, err := utils.OwnerRepo(repository)
 	if err != nil {
 		return err
@@ -125,7 +124,7 @@ func (c *Client) Subscribe(ctx context.Context, repository string) *errors.Error
 }
 
 // Unsubscribe from a repository.
-func (c *Client) Unsubscribe(ctx context.Context, repository string) *errors.Error {
+func (c *Client) Unsubscribe(ctx context.Context, repository string) error {
 	owner, reponame, err := utils.OwnerRepo(repository)
 	if err != nil {
 		return err
@@ -134,7 +133,7 @@ func (c *Client) Unsubscribe(ctx context.Context, repository string) *errors.Err
 }
 
 // Tasks returns the tasks with pagination and optional filtering. (Just pass empty values for no filters)
-func (c *Client) Tasks(ctx context.Context, repository, sha string, page, perPage int64) ([]*model.Task, *errors.Error) {
+func (c *Client) Tasks(ctx context.Context, repository, sha string, page, perPage int64) ([]*model.Task, error) {
 	tasks, err := c.client.GetTasks(ctx, page, perPage, repository, sha)
 	if err != nil {
 		return nil, err
@@ -146,12 +145,12 @@ func (c *Client) Tasks(ctx context.Context, repository, sha string, page, perPag
 }
 
 // TaskCount returns the total number of tasks matching the filter.
-func (c *Client) TaskCount(ctx context.Context, repository, sha string) (int64, *errors.Error) {
+func (c *Client) TaskCount(ctx context.Context, repository, sha string) (int64, error) {
 	return c.client.GetTasksCount(ctx, repository, sha)
 }
 
 // RunsForTask returns the runs for the provided task id.
-func (c *Client) RunsForTask(ctx context.Context, taskID, page, perPage int64) ([]*model.Run, *errors.Error) {
+func (c *Client) RunsForTask(ctx context.Context, taskID, page, perPage int64) ([]*model.Run, error) {
 	runs, err := c.client.GetTasksRunsID(ctx, taskID, page, perPage)
 	if err != nil {
 		return nil, err
@@ -162,12 +161,12 @@ func (c *Client) RunsForTask(ctx context.Context, taskID, page, perPage int64) (
 }
 
 // RunsForTaskCount returns the count of the runs for the provided task id.
-func (c *Client) RunsForTaskCount(ctx context.Context, taskID int64) (int64, *errors.Error) {
+func (c *Client) RunsForTaskCount(ctx context.Context, taskID int64) (int64, error) {
 	return c.client.GetTasksRunsIDCount(ctx, taskID)
 }
 
 // Runs returns all the runs matching the filter set with pagination.
-func (c *Client) Runs(ctx context.Context, repository, sha string, page, perPage int64) ([]*model.Run, *errors.Error) {
+func (c *Client) Runs(ctx context.Context, repository, sha string, page, perPage int64) ([]*model.Run, error) {
 	runs, err := c.client.GetRuns(ctx, page, perPage, repository, sha)
 	if err != nil {
 		return nil, err
@@ -178,12 +177,12 @@ func (c *Client) Runs(ctx context.Context, repository, sha string, page, perPage
 }
 
 // RunsCount returns the count of the runs.
-func (c *Client) RunsCount(ctx context.Context, repository, sha string) (int64, *errors.Error) {
+func (c *Client) RunsCount(ctx context.Context, repository, sha string) (int64, error) {
 	return c.client.GetRunsCount(ctx, repository, sha)
 }
 
 // GetRun retrieves a run by id.
-func (c *Client) GetRun(ctx context.Context, id int64) (*model.Run, *errors.Error) {
+func (c *Client) GetRun(ctx context.Context, id int64) (*model.Run, error) {
 	run, err := c.client.GetRunRunID(ctx, id)
 	if err != nil {
 		return nil, err
@@ -195,22 +194,22 @@ func (c *Client) GetRun(ctx context.Context, id int64) (*model.Run, *errors.Erro
 
 // CancelRun cancels the run by id. It may also cancel other runs based on rules
 // around queue management.
-func (c *Client) CancelRun(ctx context.Context, id int64) *errors.Error {
+func (c *Client) CancelRun(ctx context.Context, id int64) error {
 	return c.client.PostCancelRunID(ctx, id)
 }
 
 // AddCapability adds a capability for a user. Must have the modify:user capability to interact.
-func (c *Client) AddCapability(ctx context.Context, username string, capability model.Capability) *errors.Error {
+func (c *Client) AddCapability(ctx context.Context, username string, capability model.Capability) error {
 	return c.client.PostCapabilitiesUsernameCapability(ctx, string(capability), username)
 }
 
 // RemoveCapability removes a capability from a user. Must have the modify:user capability to interact.
-func (c *Client) RemoveCapability(ctx context.Context, username string, capability model.Capability) *errors.Error {
+func (c *Client) RemoveCapability(ctx context.Context, username string, capability model.Capability) error {
 	return c.client.DeleteCapabilitiesUsernameCapability(ctx, string(capability), username)
 }
 
 // GetUserProperties returns some properties about the requesting account; like username and capabilities.
-func (c *Client) GetUserProperties(ctx context.Context) (map[string]interface{}, *errors.Error) {
+func (c *Client) GetUserProperties(ctx context.Context) (map[string]interface{}, error) {
 	res, err := c.client.GetUserProperties(ctx)
 	if err != nil {
 		return nil, err
@@ -220,7 +219,7 @@ func (c *Client) GetUserProperties(ctx context.Context) (map[string]interface{},
 }
 
 // VisibleRepos retrieves the visible repositories to the user, a search may also be provided to limit scope.
-func (c *Client) VisibleRepos(ctx context.Context, search string) ([]*model.Repository, *errors.Error) {
+func (c *Client) VisibleRepos(ctx context.Context, search string) ([]*model.Repository, error) {
 	repos, err := c.client.GetRepositoriesVisible(ctx, search)
 	if err != nil {
 		return nil, err
@@ -231,7 +230,7 @@ func (c *Client) VisibleRepos(ctx context.Context, search string) ([]*model.Repo
 }
 
 // Submissions returns a list of submissions, paginated and optionally filtered by repository and SHA.
-func (c *Client) Submissions(ctx context.Context, repository, sha string, page, perPage int64) ([]*model.Submission, *errors.Error) {
+func (c *Client) Submissions(ctx context.Context, repository, sha string, page, perPage int64) ([]*model.Submission, error) {
 	subs, err := c.client.GetSubmissions(ctx, page, perPage, repository, sha)
 	if err != nil {
 		return nil, err
@@ -242,7 +241,7 @@ func (c *Client) Submissions(ctx context.Context, repository, sha string, page, 
 }
 
 // TasksForSubmission returns the tasks for the given submission.
-func (c *Client) TasksForSubmission(ctx context.Context, sub *model.Submission) ([]*model.Task, *errors.Error) {
+func (c *Client) TasksForSubmission(ctx context.Context, sub *model.Submission) ([]*model.Task, error) {
 	perPage := int64(20)
 	page := int64(0)
 

--- a/cmd/assetsvc/main.go
+++ b/cmd/assetsvc/main.go
@@ -25,13 +25,13 @@ func main() {
 		AppVersion:     Version,
 		TinyCIVersion:  TinyCIVersion,
 		DefaultService: config.DefaultServices.Asset,
-		RegisterService: func(s *grpc.Server, h *handler.H) *errors.Error {
+		RegisterService: func(s *grpc.Server, h *handler.H) error {
 			asset.RegisterAssetServer(s, &assetsvc.AssetServer{H: h})
 			return nil
 		},
 	}
 
 	if err := s.Make().Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }

--- a/cmd/authsvc/github-authsvc/main.go
+++ b/cmd/authsvc/github-authsvc/main.go
@@ -25,13 +25,13 @@ func main() {
 		AppVersion:     Version,
 		TinyCIVersion:  TinyCIVersion,
 		DefaultService: config.DefaultServices.Auth,
-		RegisterService: func(s *grpc.Server, h *handler.H) *errors.Error {
+		RegisterService: func(s *grpc.Server, h *handler.H) error {
 			auth.RegisterAuthServer(s, &github.AuthServer{H: h})
 			return nil
 		},
 	}
 
 	if err := s.Make().Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }

--- a/cmd/cancelbot/main.go
+++ b/cmd/cancelbot/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }
 
@@ -76,7 +76,7 @@ func run(ctx *cli.Context) error {
 		// last arg is CRL
 		cert, err = transport.LoadCert(ctx.GlobalString("cacert"), ctx.GlobalString("cert"), ctx.GlobalString("key"), "")
 		if err != nil {
-			return errors.New(err).Wrap("while loading cert")
+			return errors.New(err).(errors.Error).Wrap("while loading cert")
 		}
 	}
 

--- a/cmd/datasvc/main.go
+++ b/cmd/datasvc/main.go
@@ -27,13 +27,13 @@ func main() {
 		UseDB:          true,
 		UseSessions:    true,
 		DefaultService: config.DefaultServices.Data,
-		RegisterService: func(s *grpc.Server, h *handler.H) *errors.Error {
+		RegisterService: func(s *grpc.Server, h *handler.H) error {
 			data.RegisterDataServer(s, &datasvc.DataServer{H: h})
 			return nil
 		},
 	}
 
 	if err := s.Make().Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }

--- a/cmd/hooksvc/main.go
+++ b/cmd/hooksvc/main.go
@@ -27,7 +27,7 @@ func main() {
 	app.Action = serve
 
 	if err := app.Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }
 

--- a/cmd/logsvc/main.go
+++ b/cmd/logsvc/main.go
@@ -25,13 +25,13 @@ func main() {
 		AppVersion:     Version,
 		TinyCIVersion:  TinyCIVersion,
 		DefaultService: config.DefaultServices.Log,
-		RegisterService: func(s *grpc.Server, h *handler.H) *errors.Error {
+		RegisterService: func(s *grpc.Server, h *handler.H) error {
 			log.RegisterLogServer(s, logsvc.New(nil))
 			return nil
 		},
 	}
 
 	if err := s.Make().Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }

--- a/cmd/queuesvc/main.go
+++ b/cmd/queuesvc/main.go
@@ -25,13 +25,13 @@ func main() {
 		AppVersion:     Version,
 		TinyCIVersion:  TinyCIVersion,
 		DefaultService: config.DefaultServices.Queue,
-		RegisterService: func(s *grpc.Server, h *handler.H) *errors.Error {
+		RegisterService: func(s *grpc.Server, h *handler.H) error {
 			queue.RegisterQueueServer(s, &queuesvc.QueueServer{H: h})
 			return nil
 		},
 	}
 
 	if err := s.Make().Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }

--- a/cmd/reposvc/github-reposvc/main.go
+++ b/cmd/reposvc/github-reposvc/main.go
@@ -25,13 +25,13 @@ func main() {
 		AppVersion:     Version,
 		TinyCIVersion:  TinyCIVersion,
 		DefaultService: config.DefaultServices.Repository,
-		RegisterService: func(s *grpc.Server, h *handler.H) *errors.Error {
+		RegisterService: func(s *grpc.Server, h *handler.H) error {
 			repository.RegisterRepositoryServer(s, &github.RepositoryServer{H: h})
 			return nil
 		},
 	}
 
 	if err := s.Make().Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }

--- a/cmd/tinyci-adduser/main.go
+++ b/cmd/tinyci-adduser/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }
 
@@ -66,7 +66,7 @@ func run(ctx *cli.Context) error {
 		// last arg is CRL
 		cert, err = transport.LoadCert(ctx.GlobalString("cacert"), ctx.GlobalString("cert"), ctx.GlobalString("key"), "")
 		if err != nil {
-			return errors.New(err).Wrap("while loading cert")
+			return errors.New(err).(errors.Error).Wrap("while loading cert")
 		}
 	}
 
@@ -104,7 +104,7 @@ func run(ctx *cli.Context) error {
 	return nil
 }
 
-func inspect(token string) (*types.OAuthToken, *errors.Error) {
+func inspect(token string) (*types.OAuthToken, error) {
 	c := github.NewClientFromAccessToken(token)
 
 	login, err := c.MyLogin(context.Background())

--- a/cmd/tinycli/main.go
+++ b/cmd/tinycli/main.go
@@ -28,10 +28,10 @@ type Config struct {
 	Token    string
 }
 
-func getConfigPath(ctx *cli.Context) (string, *errors.Error) {
+func getConfigPath(ctx *cli.Context) (string, error) {
 	if fi, err := os.Stat(tinyCIConfig); err != nil {
 		if mkerr := os.MkdirAll(tinyCIConfig, 0700); mkerr != nil {
-			return "", errors.New("Could not make config dir").Wrap(mkerr).Wrap(err)
+			return "", errors.New("Could not make config dir").(errors.Error).Wrap(mkerr).Wrap(err)
 		}
 	} else if !fi.IsDir() {
 		return "", errors.Errorf("tinycli configuration path %q exists and is not a directory", tinyCIConfig)
@@ -45,7 +45,7 @@ func getConfigPath(ctx *cli.Context) (string, *errors.Error) {
 	return path.Join(tinyCIConfig, config), nil
 }
 
-func getCert(ctx *cli.Context) (*transport.Cert, *errors.Error) {
+func getCert(ctx *cli.Context) (*transport.Cert, error) {
 	ca, certStr, keyStr := ctx.GlobalString("ca"),
 		ctx.GlobalString("cert"),
 		ctx.GlobalString("key")
@@ -62,7 +62,7 @@ func getCert(ctx *cli.Context) (*transport.Cert, *errors.Error) {
 	return cert, nil
 }
 
-func loadConfig(ctx *cli.Context) (*tinyci.Client, *errors.Error) {
+func loadConfig(ctx *cli.Context) (*tinyci.Client, error) {
 	filename, e := getConfigPath(ctx)
 	if e != nil {
 		return nil, e
@@ -70,20 +70,20 @@ func loadConfig(ctx *cli.Context) (*tinyci.Client, *errors.Error) {
 
 	f, err := os.Open(filename) // #nosec
 	if err != nil {
-		return nil, errors.New(err).Wrapf("Cannot open tinyci configuration file %q", filename)
+		return nil, errors.New(err).(errors.Error).Wrapf("Cannot open tinyci configuration file %q", filename)
 	}
 	defer f.Close()
 
 	c := Config{}
 
 	if err := json.NewDecoder(f).Decode(&c); err != nil {
-		return nil, errors.New(err).Wrapf("Could not decode tinyCI JSON configuration in %q", filename)
+		return nil, errors.New(err).(errors.Error).Wrapf("Could not decode tinyCI JSON configuration in %q", filename)
 	}
 
 	return c.mkClient(ctx)
 }
 
-func (c Config) mkClient(ctx *cli.Context) (*tinyci.Client, *errors.Error) {
+func (c Config) mkClient(ctx *cli.Context) (*tinyci.Client, error) {
 	cert, err := getCert(ctx)
 	if err != nil {
 		return nil, errors.New(err)
@@ -280,7 +280,7 @@ You can also specify the TINYCLI_CONFIG environment variable.
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }
 
@@ -330,7 +330,7 @@ func doInit(ctx *cli.Context) error {
 	}
 
 	if _, err := client.Errors(context.Background()); err != nil {
-		return err.Wrap("Could not retrieve with the client, token or URL issue")
+		return err.(errors.Error).Wrap("Could not retrieve with the client, token or URL issue")
 	}
 
 	c := Config{
@@ -344,7 +344,7 @@ func doInit(ctx *cli.Context) error {
 	}
 	f, ferr := os.Create(filename)
 	if ferr != nil {
-		return errors.New(ferr).Wrapf("Could not create configuration file %v", filename)
+		return errors.New(ferr).(errors.Error).Wrapf("Could not create configuration file %v", filename)
 	}
 	defer f.Close()
 	defer fmt.Printf("Created configuration file %q\n", filename)
@@ -608,7 +608,7 @@ func log(ctx *cli.Context) error {
 
 	id, convErr := strconv.ParseInt(ctx.Args()[0], 10, 64)
 	if convErr != nil {
-		return errors.New(convErr).Wrap("Invalid ID")
+		return errors.New(convErr).(errors.Error).Wrap("Invalid ID")
 	}
 
 	return client.LogAttach(context.Background(), id, os.Stdout)

--- a/cmdlib/cmdlib.go
+++ b/cmdlib/cmdlib.go
@@ -10,7 +10,6 @@ import (
 	transport "github.com/erikh/go-transport"
 	"github.com/tinyci/ci-agents/ci-gen/grpc/handler"
 	"github.com/tinyci/ci-agents/config"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 )
@@ -22,7 +21,7 @@ type GRPCServer struct {
 	AppVersion      string
 	TinyCIVersion   string
 	DefaultService  config.ServiceAddress
-	RegisterService func(*grpc.Server, *handler.H) *errors.Error
+	RegisterService func(*grpc.Server, *handler.H) error
 	UseDB           bool
 	UseSessions     bool
 }

--- a/config/auth.go
+++ b/config/auth.go
@@ -36,7 +36,7 @@ type CertConfig struct {
 }
 
 // Validate the certificate configuration (if supplied)
-func (cc *CertConfig) Validate() *errors.Error {
+func (cc *CertConfig) Validate() error {
 	ca := strings.TrimSpace(cc.CAFile)
 	cert := strings.TrimSpace(cc.CertFile)
 	key := strings.TrimSpace(cc.KeyFile)
@@ -61,7 +61,7 @@ func (cc *CertConfig) Validate() *errors.Error {
 }
 
 // Validate ensures the auth configuration is sane.
-func (ac *AuthConfig) Validate(parseCrypt bool) *errors.Error {
+func (ac *AuthConfig) Validate(parseCrypt bool) error {
 	if parseCrypt {
 		ac.sessionCryptKey = types.DecodeKey(ac.SessionCryptKey)
 		if err := validateAESKey(ac.sessionCryptKey); err != nil {
@@ -76,7 +76,7 @@ func (ac *AuthConfig) Validate(parseCrypt bool) *errors.Error {
 	return nil
 }
 
-func validateAESKey(key []byte) *errors.Error {
+func validateAESKey(key []byte) error {
 	switch len(key) {
 	case 16, 24, 32:
 	default:
@@ -87,7 +87,7 @@ func validateAESKey(key []byte) *errors.Error {
 }
 
 // ParseTokenKey reads the key from the config, validates it, and assigns it to the appropriate variables
-func (ac *AuthConfig) ParseTokenKey() *errors.Error {
+func (ac *AuthConfig) ParseTokenKey() error {
 	ac.tokenCryptKey = types.DecodeKey(ac.TokenCryptKey)
 	if err := validateAESKey(ac.tokenCryptKey); err != nil {
 		return err
@@ -103,7 +103,7 @@ func (ac *AuthConfig) ParsedSessionCryptKey() []byte {
 }
 
 // Load loads the cert based on the provided config and returns it.
-func (cc CertConfig) Load() (*transport.Cert, *errors.Error) {
+func (cc CertConfig) Load() (*transport.Cert, error) {
 	if cc.CAFile == "" || cc.CertFile == "" || cc.KeyFile == "" {
 		fmt.Println("Some TLS parameters were missing; running insecure!")
 		return nil, nil

--- a/config/oauth.go
+++ b/config/oauth.go
@@ -28,7 +28,7 @@ type OAuthConfig struct {
 }
 
 // Validate validates the oauth configuration
-func (oc OAuthConfig) Validate() *errors.Error {
+func (oc OAuthConfig) Validate() error {
 	if strings.TrimSpace(oc.ClientID) == "" {
 		return errors.New("oauth2 client_id was missing")
 	}
@@ -43,7 +43,7 @@ func (oc OAuthConfig) Validate() *errors.Error {
 
 	_, err := url.Parse(oc.RedirectURL)
 	if err != nil {
-		return errors.New(err).Wrap("parsing oauth2 redirect_url")
+		return errors.New(err).(errors.Error).Wrap("parsing oauth2 redirect_url")
 	}
 
 	return nil

--- a/config/service.go
+++ b/config/service.go
@@ -89,7 +89,7 @@ type ClientConfig struct {
 	Cert CertConfig `yaml:"tls"`
 }
 
-func parseURL(svc, u string) *errors.Error {
+func parseURL(svc, u string) error {
 	if strings.TrimSpace(u) == "" {
 		// URLs do not need to be supplied for all services, so the services themselves
 		// will validate this later. This is just for ensuring they're actual URLs.
@@ -98,14 +98,14 @@ func parseURL(svc, u string) *errors.Error {
 
 	_, err := url.Parse(u)
 	if err != nil {
-		return errors.New(err).Wrapf("url for service %v is invalid: %q", svc, u)
+		return errors.New(err).(errors.Error).Wrapf("url for service %v is invalid: %q", svc, u)
 	}
 
 	return nil
 }
 
 // Validate validates the client configuration to ensure basic needs are met.
-func (cc *ClientConfig) Validate() *errors.Error {
+func (cc *ClientConfig) Validate() error {
 	urlmap := map[string]string{
 		"datasvc":   cc.Data,
 		"uisvc":     cc.UI,
@@ -126,7 +126,7 @@ func (cc *ClientConfig) Validate() *errors.Error {
 
 // CreateClients creates all the clients that are populated in the clients
 // struct. It will also tweak any settings for the github client.
-func (cc *ClientConfig) CreateClients(uc UserConfig, service string) (*Clients, *errors.Error) {
+func (cc *ClientConfig) CreateClients(uc UserConfig, service string) (*Clients, error) {
 	if err := cc.Validate(); err != nil {
 		return nil, err
 	}

--- a/errors/constants.go
+++ b/errors/constants.go
@@ -1,18 +1,19 @@
 package errors
 
-var errorMapping = map[string]*Error{
+var errorMapping = map[string]error{
 	"record not found": ErrNotFound,
 }
 
-// MapError finds an error by string and returns an appropriate *Error for it.
+// MapError finds an error by string and returns an appropriate Error for it.
 // The stack will NOT be preserved in the error and you will want to Wrap() it.
-// If there is no potential mapping, a new *Error is returned.
-func MapError(err interface{}) *Error {
+// If there is no potential mapping, a new Error is returned.
+func MapError(err error) error {
 	if err == nil {
 		return nil
 	}
 
-	if e, ok := errorMapping[err.(error).Error()]; ok {
+	// FIXME this is terrible. Should at least take variable input
+	if e, ok := errorMapping[err.Error()]; ok {
 		return e
 	}
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -18,7 +18,7 @@ func TestErrors(t *testing.T) {
 }
 
 func (es *errorSuite) TestWrap(c *check.C) {
-	err := New("hi")
+	err := New("hi").(Error)
 
 	c.Assert(err.Wrapf("foobar: %v", errors.New("hey there")).Error(), check.Equals, "foobar: hey there: hi")
 	c.Assert(err.Wrap("hey there").Error(), check.Equals, "hey there: hi")
@@ -26,7 +26,7 @@ func (es *errorSuite) TestWrap(c *check.C) {
 }
 
 func (es *errorSuite) TestLog(c *check.C) {
-	err := New("hi")
+	err := New("hi").(Error)
 	err.SetLog(true)
 	c.Assert(err.GetLog(), check.Equals, true)
 
@@ -38,7 +38,7 @@ func (es *errorSuite) TestLog(c *check.C) {
 }
 
 func (es *errorSuite) TestFormat(c *check.C) {
-	err := New("hi")
+	err := New("hi").(Error)
 	e2 := foo(err)
 
 	buf := fmt.Sprintf("%v", e2)
@@ -50,12 +50,12 @@ func (es *errorSuite) TestFormat(c *check.C) {
 }
 
 func (es *errorSuite) TestContains(c *check.C) {
-	err := New("hi")
+	err := New("hi").(Error)
 	e2 := foo(err)
 	c.Assert(e2.Contains(err), check.Equals, true)
 	c.Assert(e2.Contains(New("nope")), check.Equals, false)
 }
 
-func foo(err *Error) *Error {
+func foo(err Error) Error {
 	return err.Wrap("in foo")
 }

--- a/handlers/route.go
+++ b/handlers/route.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/model"
 	"golang.org/x/net/websocket"
 )
@@ -19,18 +18,18 @@ type Route struct {
 	UseCORS            bool
 	UseAuth            bool
 	WebsocketProcessor WebsocketFunc
-	Handler            func(*H, *gin.Context, HandlerFunc) *errors.Error
+	Handler            func(*H, *gin.Context, HandlerFunc) error
 	Processor          HandlerFunc
-	ParamValidator     func(*H, *gin.Context) *errors.Error
+	ParamValidator     func(*H, *gin.Context) error
 	Capability         model.Capability
 	TokenScope         string
 }
 
 // HandlerFunc is the basic kind of HandlerFunc.
-type HandlerFunc func(context.Context, *H, *gin.Context) (interface{}, int, *errors.Error)
+type HandlerFunc func(context.Context, *H, *gin.Context) (interface{}, int, error)
 
 // WebsocketFunc is the controller for websocket operations.
-type WebsocketFunc func(context.Context, *H, *gin.Context, *websocket.Conn) *errors.Error
+type WebsocketFunc func(context.Context, *H, *gin.Context, *websocket.Conn) error
 
 // SetProcessor allows you to more simply set the processor for a given route.
 func (r Routes) SetProcessor(route string, method string, processor HandlerFunc) {

--- a/mocks/github/mock.go
+++ b/mocks/github/mock.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	github "github.com/google/go-github/github"
-	errors "github.com/tinyci/ci-agents/errors"
 	reflect "reflect"
 )
 
@@ -36,10 +35,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // ClearStates mocks base method
-func (m *MockClient) ClearStates(arg0 context.Context, arg1, arg2 string) *errors.Error {
+func (m *MockClient) ClearStates(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClearStates", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*errors.Error)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
@@ -50,10 +49,10 @@ func (mr *MockClientMockRecorder) ClearStates(arg0, arg1, arg2 interface{}) *gom
 }
 
 // CommentError mocks base method
-func (m *MockClient) CommentError(arg0 context.Context, arg1 string, arg2 int64, arg3 *errors.Error) *errors.Error {
+func (m *MockClient) CommentError(arg0 context.Context, arg1 string, arg2 int64, arg3 error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CommentError", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*errors.Error)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
@@ -64,10 +63,10 @@ func (mr *MockClientMockRecorder) CommentError(arg0, arg1, arg2, arg3 interface{
 }
 
 // ErrorStatus mocks base method
-func (m *MockClient) ErrorStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string, arg6 *errors.Error) *errors.Error {
+func (m *MockClient) ErrorStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string, arg6 error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ErrorStatus", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
-	ret0, _ := ret[0].(*errors.Error)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
@@ -78,10 +77,10 @@ func (mr *MockClientMockRecorder) ErrorStatus(arg0, arg1, arg2, arg3, arg4, arg5
 }
 
 // FinishedStatus mocks base method
-func (m *MockClient) FinishedStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string, arg6 bool, arg7 string) *errors.Error {
+func (m *MockClient) FinishedStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string, arg6 bool, arg7 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FinishedStatus", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-	ret0, _ := ret[0].(*errors.Error)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
@@ -92,11 +91,11 @@ func (mr *MockClientMockRecorder) FinishedStatus(arg0, arg1, arg2, arg3, arg4, a
 }
 
 // GetDiffFiles mocks base method
-func (m *MockClient) GetDiffFiles(arg0 context.Context, arg1, arg2, arg3 string) ([]string, *errors.Error) {
+func (m *MockClient) GetDiffFiles(arg0 context.Context, arg1, arg2, arg3 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDiffFiles", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(*errors.Error)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
@@ -107,11 +106,11 @@ func (mr *MockClientMockRecorder) GetDiffFiles(arg0, arg1, arg2, arg3 interface{
 }
 
 // GetFile mocks base method
-func (m *MockClient) GetFile(arg0 context.Context, arg1, arg2, arg3 string) ([]byte, *errors.Error) {
+func (m *MockClient) GetFile(arg0 context.Context, arg1, arg2, arg3 string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFile", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(*errors.Error)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
@@ -122,11 +121,11 @@ func (mr *MockClientMockRecorder) GetFile(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // GetFileList mocks base method
-func (m *MockClient) GetFileList(arg0 context.Context, arg1, arg2 string) ([]string, *errors.Error) {
+func (m *MockClient) GetFileList(arg0 context.Context, arg1, arg2 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFileList", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(*errors.Error)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
@@ -137,11 +136,11 @@ func (mr *MockClientMockRecorder) GetFileList(arg0, arg1, arg2 interface{}) *gom
 }
 
 // GetRefs mocks base method
-func (m *MockClient) GetRefs(arg0 context.Context, arg1, arg2 string) ([]string, *errors.Error) {
+func (m *MockClient) GetRefs(arg0 context.Context, arg1, arg2 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRefs", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(*errors.Error)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
@@ -152,11 +151,11 @@ func (mr *MockClientMockRecorder) GetRefs(arg0, arg1, arg2 interface{}) *gomock.
 }
 
 // GetRepository mocks base method
-func (m *MockClient) GetRepository(arg0 context.Context, arg1 string) (*github.Repository, *errors.Error) {
+func (m *MockClient) GetRepository(arg0 context.Context, arg1 string) (*github.Repository, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRepository", arg0, arg1)
 	ret0, _ := ret[0].(*github.Repository)
-	ret1, _ := ret[1].(*errors.Error)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
@@ -167,11 +166,11 @@ func (mr *MockClientMockRecorder) GetRepository(arg0, arg1 interface{}) *gomock.
 }
 
 // GetSHA mocks base method
-func (m *MockClient) GetSHA(arg0 context.Context, arg1, arg2 string) (string, *errors.Error) {
+func (m *MockClient) GetSHA(arg0 context.Context, arg1, arg2 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSHA", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(*errors.Error)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
@@ -182,11 +181,11 @@ func (mr *MockClientMockRecorder) GetSHA(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // MyLogin mocks base method
-func (m *MockClient) MyLogin(arg0 context.Context) (string, *errors.Error) {
+func (m *MockClient) MyLogin(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MyLogin", arg0)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(*errors.Error)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
@@ -197,11 +196,11 @@ func (mr *MockClientMockRecorder) MyLogin(arg0 interface{}) *gomock.Call {
 }
 
 // MyRepositories mocks base method
-func (m *MockClient) MyRepositories(arg0 context.Context) ([]*github.Repository, *errors.Error) {
+func (m *MockClient) MyRepositories(arg0 context.Context) ([]*github.Repository, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MyRepositories", arg0)
 	ret0, _ := ret[0].([]*github.Repository)
-	ret1, _ := ret[1].(*errors.Error)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
@@ -212,10 +211,10 @@ func (mr *MockClientMockRecorder) MyRepositories(arg0 interface{}) *gomock.Call 
 }
 
 // PendingStatus mocks base method
-func (m *MockClient) PendingStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) *errors.Error {
+func (m *MockClient) PendingStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PendingStatus", arg0, arg1, arg2, arg3, arg4, arg5)
-	ret0, _ := ret[0].(*errors.Error)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
@@ -226,10 +225,10 @@ func (mr *MockClientMockRecorder) PendingStatus(arg0, arg1, arg2, arg3, arg4, ar
 }
 
 // SetupHook mocks base method
-func (m *MockClient) SetupHook(arg0 context.Context, arg1, arg2, arg3, arg4 string) *errors.Error {
+func (m *MockClient) SetupHook(arg0 context.Context, arg1, arg2, arg3, arg4 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetupHook", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(*errors.Error)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
@@ -240,10 +239,10 @@ func (mr *MockClientMockRecorder) SetupHook(arg0, arg1, arg2, arg3, arg4 interfa
 }
 
 // StartedStatus mocks base method
-func (m *MockClient) StartedStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) *errors.Error {
+func (m *MockClient) StartedStatus(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartedStatus", arg0, arg1, arg2, arg3, arg4, arg5)
-	ret0, _ := ret[0].(*errors.Error)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
@@ -254,10 +253,10 @@ func (mr *MockClientMockRecorder) StartedStatus(arg0, arg1, arg2, arg3, arg4, ar
 }
 
 // TeardownHook mocks base method
-func (m *MockClient) TeardownHook(arg0 context.Context, arg1, arg2, arg3 string) *errors.Error {
+func (m *MockClient) TeardownHook(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TeardownHook", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*errors.Error)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -15,7 +15,7 @@ type Model struct {
 }
 
 // New returns the model structure after the db connection work has taken place.
-func New(sqlURL string) (*Model, *errors.Error) {
+func New(sqlURL string) (*Model, error) {
 	db, err := gorm.Open("postgres", sqlURL)
 	if err != nil {
 		return nil, errors.New(err)
@@ -38,6 +38,10 @@ func New(sqlURL string) (*Model, *errors.Error) {
 // stack-annotated error with the msg if there is one; otherwise it will return
 // nil. It also uses the errors package to normalize common errors returned
 // from the DB.
-func (m *Model) WrapError(call *gorm.DB, msg string) *errors.Error {
-	return errors.MapError(call.Error).Wrap(msg)
+func (m *Model) WrapError(call *gorm.DB, msg string) error {
+	if call.Error == nil {
+		return nil
+	}
+
+	return errors.MapError(call.Error).(errors.Error).Wrap(msg)
 }

--- a/model/oauth.go
+++ b/model/oauth.go
@@ -49,7 +49,7 @@ func (o *OAuth) GetScopes() map[string]struct{} {
 
 // OAuthRegisterState registers a state code in a uniqueness table that tracks
 // it.
-func (m *Model) OAuthRegisterState(state string, scopes []string) *errors.Error {
+func (m *Model) OAuthRegisterState(state string, scopes []string) error {
 	oa := &OAuth{
 		State:     state,
 		ExpiresOn: time.Now().Add(OAuthExpiration),
@@ -60,12 +60,12 @@ func (m *Model) OAuthRegisterState(state string, scopes []string) *errors.Error 
 }
 
 // OAuthValidateState validates that the state we sent actually exists and is
-// ready to be consumed. In the event it is not, it returns *errors.Error.
-func (m *Model) OAuthValidateState(state string) (*OAuth, *errors.Error) {
+// ready to be consumed. In the event it is not, it returns error.
+func (m *Model) OAuthValidateState(state string) (*OAuth, error) {
 	oa := &OAuth{}
 	err := m.WrapError(m.Where("state = ? and expires_on > now()", state).Find(&oa), "validating oauth state")
 	if err != nil {
-		return nil, errors.New(err).Wrap(errors.ErrNotFound)
+		return nil, errors.New(err).(errors.Error).Wrap(errors.ErrNotFound)
 	}
 
 	defer m.Delete(&OAuth{State: state})

--- a/model/queue.go
+++ b/model/queue.go
@@ -22,7 +22,7 @@ type QueueItem struct {
 }
 
 // NewQueueItemFromProto converts in the opposite direction of ToProto.
-func NewQueueItemFromProto(tqi *types.QueueItem) (*QueueItem, *errors.Error) {
+func NewQueueItemFromProto(tqi *types.QueueItem) (*QueueItem, error) {
 	run, err := NewRunFromProto(tqi.Run)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (qi *QueueItem) ToProto() *types.QueueItem {
 // hook chain
 func (qi *QueueItem) AfterFind(tx *gorm.DB) error {
 	if err := qi.Validate(); err != nil {
-		return errors.New(err).Wrapf("reading queue item %d", qi.ID)
+		return errors.New(err).(errors.Error).Wrapf("reading queue item %d", qi.ID)
 	}
 
 	return nil
@@ -79,14 +79,14 @@ func (qi *QueueItem) BeforeCreate(tx *gorm.DB) error {
 // BeforeSave is a gorm hook to marshal the token JSON before saving the record
 func (qi *QueueItem) BeforeSave(tx *gorm.DB) error {
 	if err := qi.Validate(); err != nil {
-		return errors.New(err).Wrapf("saving queue item %d", qi.ID)
+		return errors.New(err).(errors.Error).Wrapf("saving queue item %d", qi.ID)
 	}
 
 	return nil
 }
 
 // Validate the item. if passed true, will validate for creation scenarios
-func (qi *QueueItem) Validate() *errors.Error {
+func (qi *QueueItem) Validate() error {
 	if qi.Run == nil {
 		return errors.New("run was nil")
 	}
@@ -99,14 +99,14 @@ func (qi *QueueItem) Validate() *errors.Error {
 }
 
 // QueueTotalCount returns the number of items in the queue
-func (m *Model) QueueTotalCount() (int64, *errors.Error) {
+func (m *Model) QueueTotalCount() (int64, error) {
 	var ret int64
 	return ret, m.WrapError(m.Table("queue_items").Count(&ret), "computing total queue count")
 }
 
 // QueueTotalCountForRepository returns the number of items in the queue where
 // the parent fork matches the repository name given
-func (m *Model) QueueTotalCountForRepository(repo *Repository) (int64, *errors.Error) {
+func (m *Model) QueueTotalCountForRepository(repo *Repository) (int64, error) {
 	var ret int64
 	return ret, m.WrapError(
 		m.Table("queue_items").
@@ -122,7 +122,7 @@ func (m *Model) QueueTotalCountForRepository(repo *Repository) (int64, *errors.E
 
 // NextQueueItem returns the next item in the named queue. If for some reason the
 // queueName is an empty string, the string `default` will be used instead.
-func (m *Model) NextQueueItem(runningOn string, queueName string) (*QueueItem, *errors.Error) {
+func (m *Model) NextQueueItem(runningOn string, queueName string) (*QueueItem, error) {
 	if queueName == "" {
 		queueName = "default"
 	}
@@ -173,7 +173,7 @@ func (m *Model) NextQueueItem(runningOn string, queueName string) (*QueueItem, *
 }
 
 // QueueList returns a list of queue items with pagination.
-func (m *Model) QueueList(page, perPage int64) ([]*QueueItem, *errors.Error) {
+func (m *Model) QueueList(page, perPage int64) ([]*QueueItem, error) {
 	qis := []*QueueItem{}
 
 	page, perPage, err := utils.ScopePaginationInt(page, perPage)
@@ -185,7 +185,7 @@ func (m *Model) QueueList(page, perPage int64) ([]*QueueItem, *errors.Error) {
 }
 
 // QueueListForRepository returns a list of queue items with pagination.
-func (m *Model) QueueListForRepository(repo *Repository, page, perPage int64) ([]*QueueItem, *errors.Error) {
+func (m *Model) QueueListForRepository(repo *Repository, page, perPage int64) ([]*QueueItem, error) {
 	qis := []*QueueItem{}
 
 	page, perPage, err := utils.ScopePaginationInt(page, perPage)
@@ -209,7 +209,7 @@ func (m *Model) QueueListForRepository(repo *Repository, page, perPage int64) ([
 }
 
 // QueuePipelineAdd adds a group of queue items in a transaction.
-func (m *Model) QueuePipelineAdd(qis []*QueueItem) ([]*QueueItem, *errors.Error) {
+func (m *Model) QueuePipelineAdd(qis []*QueueItem) ([]*QueueItem, error) {
 	db := m.Begin()
 	defer db.Rollback()
 

--- a/model/ref.go
+++ b/model/ref.go
@@ -18,7 +18,7 @@ type Ref struct {
 }
 
 // NewRefFromProto converts a proto ref to a real ref.
-func NewRefFromProto(r *types.Ref) (*Ref, *errors.Error) {
+func NewRefFromProto(r *types.Ref) (*Ref, error) {
 	repo, err := NewRepositoryFromProto(r.Repository)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (r *Ref) ToProto() *types.Ref {
 }
 
 // Validate validates the ref before saving it and after fetching it.
-func (r *Ref) Validate() *errors.Error {
+func (r *Ref) Validate() error {
 	if r.Repository == nil {
 		return errors.New("invalid repository")
 	}
@@ -67,7 +67,7 @@ func (r *Ref) Validate() *errors.Error {
 // hook chain
 func (r *Ref) AfterFind(tx *gorm.DB) error {
 	if err := r.Validate(); err != nil {
-		return errors.New(err).Wrapf("reading ref id %d (%q)", r.ID, r.SHA)
+		return errors.New(err).(errors.Error).Wrapf("reading ref id %d (%q)", r.ID, r.SHA)
 	}
 
 	return nil
@@ -81,14 +81,14 @@ func (r *Ref) BeforeCreate(tx *gorm.DB) error {
 // BeforeSave is a gorm hook to marshal the token JSON before saving the record
 func (r *Ref) BeforeSave(tx *gorm.DB) error {
 	if err := r.Validate(); err != nil {
-		return errors.New(err).Wrapf("saving ref %q (%q)", r.RefName, r.SHA)
+		return errors.New(err).(errors.Error).Wrapf("saving ref %q (%q)", r.RefName, r.SHA)
 	}
 
 	return nil
 }
 
 // GetRefByNameAndSHA returns the ref matching the name/sha combination.
-func (m *Model) GetRefByNameAndSHA(repoName string, sha string) (*Ref, *errors.Error) {
+func (m *Model) GetRefByNameAndSHA(repoName string, sha string) (*Ref, error) {
 	ref := &Ref{}
 	err := m.WrapError(
 		m.Joins("inner join repositories on refs.repository_id = repositories.id").
@@ -100,7 +100,7 @@ func (m *Model) GetRefByNameAndSHA(repoName string, sha string) (*Ref, *errors.E
 }
 
 // PutRef adds the ref to the database.
-func (m *Model) PutRef(ref *Ref) *errors.Error {
+func (m *Model) PutRef(ref *Ref) error {
 	return m.WrapError(m.Create(ref), "creating ref")
 }
 
@@ -110,7 +110,7 @@ func (m *Model) PutRef(ref *Ref) *errors.Error {
 // Do note that it does not match the SHA; more often than not this is caused
 // by an --amend + force push which updates the SHA, or a new commit which also
 // changes the SHA. The name is the only reliable data in this case.
-func (m *Model) CancelRefByName(repoID int64, refName, baseURL string, gh github.Client) *errors.Error {
+func (m *Model) CancelRefByName(repoID int64, refName, baseURL string, gh github.Client) error {
 	tasks := []*Task{}
 
 	repo := &Repository{}

--- a/model/repository.go
+++ b/model/repository.go
@@ -58,7 +58,7 @@ type Repository struct {
 }
 
 // NewRepositoryFromProto converts a proto repository to a model repository.
-func NewRepositoryFromProto(r *types.Repository) (*Repository, *errors.Error) {
+func NewRepositoryFromProto(r *types.Repository) (*Repository, error) {
 	github := &gh.Repository{}
 	if err := json.Unmarshal(r.Github, github); err != nil {
 		return nil, errors.New(err)
@@ -67,7 +67,7 @@ func NewRepositoryFromProto(r *types.Repository) (*Repository, *errors.Error) {
 	var owner *User
 
 	if r.Owner != nil {
-		var err *errors.Error
+		var err error
 		owner, err = NewUserFromProto(r.Owner)
 		if err != nil {
 			return nil, err
@@ -108,13 +108,13 @@ func (r *Repository) ToProto() *types.Repository {
 }
 
 // OwnerRepo validates the owner/repo github path then returns each part.
-func (r *Repository) OwnerRepo() (string, string, *errors.Error) {
+func (r *Repository) OwnerRepo() (string, string, error) {
 	return utils.OwnerRepo(r.Name)
 }
 
 // GetRepositoryByNameForUser retrieves the repository by name if the user can
 // see it (aka, if it's not private or if it's owned by them)
-func (m *Model) GetRepositoryByNameForUser(name string, u *User) (*Repository, *errors.Error) {
+func (m *Model) GetRepositoryByNameForUser(name string, u *User) (*Repository, error) {
 	r := &Repository{}
 
 	var id int64
@@ -126,13 +126,13 @@ func (m *Model) GetRepositoryByNameForUser(name string, u *User) (*Repository, *
 }
 
 // GetOwnedRepos returns all repos the user owns.
-func (m *Model) GetOwnedRepos(u *User, search string) (RepositoryList, *errors.Error) {
+func (m *Model) GetOwnedRepos(u *User, search string) (RepositoryList, error) {
 	return m.getRepoSearch("owner_id = ?", search, u.ID)
 }
 
 // GetVisibleReposForUser retrieves all repos the user can "see" in the
 // database.
-func (m *Model) GetVisibleReposForUser(u *User, search string) (RepositoryList, *errors.Error) {
+func (m *Model) GetVisibleReposForUser(u *User, search string) (RepositoryList, error) {
 	r, err := m.GetAllPublicRepos(search)
 	if err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ func (m *Model) GetVisibleReposForUser(u *User, search string) (RepositoryList, 
 	return append(r2, r...), nil
 }
 
-func (m *Model) getRepoSearch(where, search string, args ...interface{}) (RepositoryList, *errors.Error) {
+func (m *Model) getRepoSearch(where, search string, args ...interface{}) (RepositoryList, error) {
 	r := []*Repository{}
 
 	search = strings.Replace(search, "%", "\\%", -1)
@@ -161,17 +161,17 @@ func (m *Model) getRepoSearch(where, search string, args ...interface{}) (Reposi
 }
 
 // GetAllPublicRepos retrieves all repos that are not private
-func (m *Model) GetAllPublicRepos(search string) (RepositoryList, *errors.Error) {
+func (m *Model) GetAllPublicRepos(search string) (RepositoryList, error) {
 	return m.getRepoSearch("not private", search)
 }
 
 // GetPrivateReposForUser retrieves all private repos that the user owns.
-func (m *Model) GetPrivateReposForUser(u *User, search string) (RepositoryList, *errors.Error) {
+func (m *Model) GetPrivateReposForUser(u *User, search string) (RepositoryList, error) {
 	return m.getRepoSearch("owner_id = ? and private", search, u.ID)
 }
 
 // GetRepositoryByName retrieves the repository by its unique name.
-func (m *Model) GetRepositoryByName(name string) (*Repository, *errors.Error) {
+func (m *Model) GetRepositoryByName(name string) (*Repository, error) {
 	r := &Repository{}
 	return r, m.WrapError(m.Where("name = ?", name).First(r), "obtain repository by name")
 }
@@ -180,11 +180,11 @@ func (m *Model) GetRepositoryByName(name string) (*Repository, *errors.Error) {
 // hook chain
 func (r *Repository) AfterFind(tx *gorm.DB) error {
 	if err := json.Unmarshal(r.GithubJSON, &r.Github); err != nil {
-		return errors.New(err).Wrapf("reading github repository for id %d (%q)", r.ID, r.Name)
+		return errors.New(err).(errors.Error).Wrapf("reading github repository for id %d (%q)", r.ID, r.Name)
 	}
 
 	if err := r.Validate(false); err != nil {
-		return errors.New(err).Wrapf("reading repository id %d (%q)", r.ID, r.Name)
+		return errors.New(err).(errors.Error).Wrapf("reading repository id %d (%q)", r.ID, r.Name)
 	}
 
 	return nil
@@ -198,20 +198,20 @@ func (r *Repository) BeforeCreate(tx *gorm.DB) error {
 // BeforeSave is a gorm hook to marshal the token JSON before saving the record
 func (r *Repository) BeforeSave(tx *gorm.DB) error {
 	if err := r.Validate(true); err != nil {
-		return errors.New(err).Wrapf("saving repository %q", r.Name)
+		return errors.New(err).(errors.Error).Wrapf("saving repository %q", r.Name)
 	}
 
 	var err error
 	r.GithubJSON, err = json.Marshal(&r.Github)
 	if err != nil {
-		return errors.New(err).Wrapf("reading github repository for id %d (%q)", r.ID, r.Name)
+		return errors.New(err).(errors.Error).Wrapf("reading github repository for id %d (%q)", r.ID, r.Name)
 	}
 
 	return nil
 }
 
 // Validate validates the repository object
-func (r *Repository) Validate(validOwner bool) *errors.Error {
+func (r *Repository) Validate(validOwner bool) error {
 	if r.Name == "" {
 		return errors.New("name is empty")
 	}
@@ -233,7 +233,7 @@ func (r *Repository) Enabled() bool {
 }
 
 // DisableRepository removes it from CI.
-func (m *Model) DisableRepository(repo *Repository) *errors.Error {
+func (m *Model) DisableRepository(repo *Repository) error {
 	if !repo.Enabled() {
 		return errors.New("repo is not enabled")
 	}
@@ -243,7 +243,7 @@ func (m *Model) DisableRepository(repo *Repository) *errors.Error {
 }
 
 // EnableRepository adds it to CI.
-func (m *Model) EnableRepository(repo *Repository, owner *User) *errors.Error {
+func (m *Model) EnableRepository(repo *Repository, owner *User) error {
 	if repo.Enabled() {
 		return errors.New("repo is already enabled")
 	}
@@ -255,7 +255,7 @@ func (m *Model) EnableRepository(repo *Repository, owner *User) *errors.Error {
 }
 
 // AssignRepository assigns the repository to the user explicitly.
-func (m *Model) AssignRepository(repo *Repository, owner *User) *errors.Error {
+func (m *Model) AssignRepository(repo *Repository, owner *User) error {
 	repo.Owner = owner
 	return m.WrapError(m.Save(repo), fmt.Sprintf("assigning repository to %q", owner.Username))
 }

--- a/model/run.go
+++ b/model/run.go
@@ -42,7 +42,7 @@ type Run struct {
 }
 
 // NewRunFromProto yields a new run from a protobuf message.
-func NewRunFromProto(r *gtypes.Run) (*Run, *errors.Error) {
+func NewRunFromProto(r *gtypes.Run) (*Run, error) {
 	task, err := NewTaskFromProto(r.Task)
 	if err != nil {
 		return nil, err
@@ -100,8 +100,8 @@ func (r *Run) ToProto() *gtypes.Run {
 }
 
 // Validate validates the run record, accounting for creation or modification.
-// Returns *errors.Error on any found.
-func (r *Run) Validate() *errors.Error {
+// Returns error on any found.
+func (r *Run) Validate() error {
 	if r.Name == "" {
 		return errors.New("missing name")
 	}
@@ -121,11 +121,11 @@ func (r *Run) Validate() *errors.Error {
 // hook chain
 func (r *Run) AfterFind(tx *gorm.DB) error {
 	if err := json.Unmarshal(r.RunSettingsJSON, &r.RunSettings); err != nil {
-		return errors.New(err).Wrapf("unpacking task settings for task %d", r.ID)
+		return errors.New(err).(errors.Error).Wrapf("unpacking task settings for task %d", r.ID)
 	}
 
 	if err := r.Validate(); err != nil {
-		return errors.New(err).Wrapf("reading task id %d", r.ID)
+		return errors.New(err).(errors.Error).Wrapf("reading task id %d", r.ID)
 	}
 
 	return nil
@@ -139,20 +139,20 @@ func (r *Run) BeforeCreate(tx *gorm.DB) error {
 // BeforeSave is a gorm hook to marshal the token JSON before saving the record
 func (r *Run) BeforeSave(tx *gorm.DB) error {
 	if err := r.Validate(); err != nil {
-		return errors.New(err).Wrapf("saving task id %d", r.ID)
+		return errors.New(err).(errors.Error).Wrapf("saving task id %d", r.ID)
 	}
 
 	var err error
 	r.RunSettingsJSON, err = json.Marshal(r.RunSettings)
 	if err != nil {
-		return errors.New(err).Wrapf("marshaling settings for task id %d", r.ID)
+		return errors.New(err).(errors.Error).Wrapf("marshaling settings for task id %d", r.ID)
 	}
 
 	return nil
 }
 
 // SetRunStatus sets the status for the run; fails if it is already set.
-func (m *Model) SetRunStatus(runID int64, gh github.Client, status, canceled bool, url, addlMessage string) *errors.Error {
+func (m *Model) SetRunStatus(runID int64, gh github.Client, status, canceled bool, url, addlMessage string) error {
 	run := &Run{}
 
 	if err := m.WrapError(m.Where("id = ?", runID).First(run), "finding run to set status"); err != nil {
@@ -166,11 +166,11 @@ func (m *Model) SetRunStatus(runID int64, gh github.Client, status, canceled boo
 	qi := &QueueItem{}
 
 	if err := m.WrapError(m.Where("run_id = ?", runID).First(qi), "finding queue item to clear during status update"); err != nil {
-		return errors.New(err).Wrapf("locating queue item for run %d", runID)
+		return errors.New(err).(errors.Error).Wrapf("locating queue item for run %d", runID)
 	}
 
 	if err := m.WrapError(m.Delete(qi), "deleting queue item during status update"); err != nil {
-		return errors.New(err).Wrapf("while deleting queue item %d", qi.ID)
+		return errors.New(err).(errors.Error).Wrapf("while deleting queue item %d", qi.ID)
 	}
 
 	bits, err := m.getRunBits(runID, gh)
@@ -203,7 +203,7 @@ func (m *Model) SetRunStatus(runID int64, gh github.Client, status, canceled boo
 }
 
 // CancelRun is a thin facade for the CancelTask functionality, loading the record from the ID provided.
-func (m *Model) CancelRun(runID int64, baseURL string, gh github.Client) *errors.Error {
+func (m *Model) CancelRun(runID int64, baseURL string, gh github.Client) error {
 	run := &Run{}
 
 	if err := m.WrapError(m.Where("id = ?", runID).First(run), "locating run for cancel"); err != nil {
@@ -215,7 +215,7 @@ func (m *Model) CancelRun(runID int64, baseURL string, gh github.Client) *errors
 
 // GetCancelForRun satisfies the datasvc interface by finding the underlying
 // task's canceled state.
-func (m *Model) GetCancelForRun(runID int64) (bool, *errors.Error) {
+func (m *Model) GetCancelForRun(runID int64) (bool, error) {
 	run := &Run{}
 
 	if err := m.WrapError(m.Where("id = ?", runID).First(run), "locating run to report cancel state"); err != nil {
@@ -225,7 +225,7 @@ func (m *Model) GetCancelForRun(runID int64) (bool, *errors.Error) {
 	return run.Task.Canceled, nil
 }
 
-func (m *Model) getRunBits(runID int64, gh github.Client) (*runBits, *errors.Error) {
+func (m *Model) getRunBits(runID int64, gh github.Client) (*runBits, error) {
 	run := &Run{}
 
 	load := m.DB
@@ -240,7 +240,7 @@ func (m *Model) getRunBits(runID int64, gh github.Client) (*runBits, *errors.Err
 
 	owner, repo, err := run.Task.Submission.BaseRef.Repository.OwnerRepo()
 	if err != nil {
-		return nil, err.Wrapf("invalid repository for run %d: %v", run.ID, run.Task.Submission.HeadRef.Repository.Name)
+		return nil, err.(errors.Error).Wrapf("invalid repository for run %d: %v", run.ID, run.Task.Submission.HeadRef.Repository.Name)
 	}
 
 	if gh == nil {
@@ -258,7 +258,7 @@ func (m *Model) getRunBits(runID int64, gh github.Client) (*runBits, *errors.Err
 }
 
 // RunList returns a list of runs with pagination.
-func (m *Model) RunList(page, perPage int64, repository, sha string) ([]*Run, *errors.Error) {
+func (m *Model) RunList(page, perPage int64, repository, sha string) ([]*Run, error) {
 	runs := []*Run{}
 
 	page, perPage, err := utils.ScopePaginationInt(page, perPage)
@@ -291,7 +291,7 @@ func (m *Model) RunList(page, perPage int64, repository, sha string) ([]*Run, *e
 
 // RunListForRepository returns a list of queue items with pagination. If ref
 // is non-nil, it will isolate to the ref only.
-func (m *Model) RunListForRepository(repo *Repository, ref *Ref, page, perPage int64) ([]*Run, *errors.Error) {
+func (m *Model) RunListForRepository(repo *Repository, ref *Ref, page, perPage int64) ([]*Run, error) {
 	runs := []*Run{}
 
 	page, perPage, err := utils.ScopePaginationInt(page, perPage)
@@ -317,14 +317,14 @@ func (m *Model) RunListForRepository(repo *Repository, ref *Ref, page, perPage i
 }
 
 // RunTotalCount returns the number of items in the runs table
-func (m *Model) RunTotalCount() (int64, *errors.Error) {
+func (m *Model) RunTotalCount() (int64, error) {
 	var ret int64
 	return ret, m.WrapError(m.Table("runs").Count(&ret), "counting runs")
 }
 
 // RunTotalCountForRepository returns the number of items in the queue where
 // the parent fork matches the repository name given
-func (m *Model) RunTotalCountForRepository(repo *Repository) (int64, *errors.Error) {
+func (m *Model) RunTotalCountForRepository(repo *Repository) (int64, error) {
 	var ret int64
 	return ret, m.WrapError(
 		m.Table("runs").
@@ -340,7 +340,7 @@ func (m *Model) RunTotalCountForRepository(repo *Repository) (int64, *errors.Err
 
 // RunTotalCountForRepositoryAndSHA returns the number of items in the queue where
 // the parent fork matches the repository name given
-func (m *Model) RunTotalCountForRepositoryAndSHA(repo *Repository, sha string) (int64, *errors.Error) {
+func (m *Model) RunTotalCountForRepositoryAndSHA(repo *Repository, sha string) (int64, error) {
 	var ret int64
 	return ret, m.WrapError(
 		m.Table("runs").
@@ -355,7 +355,7 @@ func (m *Model) RunTotalCountForRepositoryAndSHA(repo *Repository, sha string) (
 }
 
 // RunsForTicket all the runs that belong to a repository's PR.
-func (m *Model) RunsForTicket(repoName string, ticketID int) ([]*Run, *errors.Error) {
+func (m *Model) RunsForTicket(repoName string, ticketID int) ([]*Run, error) {
 	ret := []*Run{}
 
 	return ret, m.WrapError(

--- a/model/session.go
+++ b/model/session.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/tinyci/ci-agents/ci-gen/grpc/types"
-	"github.com/tinyci/ci-agents/errors"
 )
 
 // Session corresponds to the `sessions` table and encapsulates a web session.
@@ -33,12 +32,12 @@ func (s *Session) ToProto() *types.Session {
 }
 
 // LoadSession loads a session based on the key and returns it to the client
-func (m *Model) LoadSession(id string) (*Session, *errors.Error) {
+func (m *Model) LoadSession(id string) (*Session, error) {
 	s := &Session{}
 	return s, m.WrapError(m.Limit(1).Where("key = ? and expires_on > now()", id).First(s), "loading session")
 }
 
 // SaveSession does the opposite of LoadSession
-func (m *Model) SaveSession(session *Session) *errors.Error {
+func (m *Model) SaveSession(session *Session) error {
 	return m.WrapError(m.Save(session), "saving session")
 }

--- a/model/submission.go
+++ b/model/submission.go
@@ -75,30 +75,30 @@ func (s *Submission) ToProto() *gtypes.Submission {
 }
 
 // NewSubmissionFromProto converts the proto representation to the task type.
-func NewSubmissionFromProto(gt *gtypes.Submission) (*Submission, *errors.Error) {
+func NewSubmissionFromProto(gt *gtypes.Submission) (*Submission, error) {
 	var (
 		u       *User
 		headref *Ref
-		err     *errors.Error
+		err     error
 	)
 
 	if gt.User != nil {
 		u, err = NewUserFromProto(gt.User)
 		if err != nil {
-			return nil, err.Wrap("converting for use in submission")
+			return nil, err.(errors.Error).Wrap("converting for use in submission")
 		}
 	}
 
 	if gt.HeadRef != nil {
 		headref, err = NewRefFromProto(gt.HeadRef)
 		if err != nil {
-			return nil, err.Wrap("converting for use in submission")
+			return nil, err.(errors.Error).Wrap("converting for use in submission")
 		}
 	}
 
 	baseref, err := NewRefFromProto(gt.BaseRef)
 	if err != nil {
-		return nil, err.Wrap("converting for use in submission")
+		return nil, err.(errors.Error).Wrap("converting for use in submission")
 	}
 
 	if headref == nil {
@@ -139,34 +139,34 @@ func NewSubmissionFromProto(gt *gtypes.Submission) (*Submission, *errors.Error) 
 
 // NewSubmissionFromMessage creates a blank record populated by the appropriate data
 // reaped from the message type in types/submission.go.
-func (m *Model) NewSubmissionFromMessage(sub *types.Submission) (*Submission, *errors.Error) {
+func (m *Model) NewSubmissionFromMessage(sub *types.Submission) (*Submission, error) {
 	if err := sub.Validate(); err != nil {
-		return nil, err.Wrap("did not pass validation")
+		return nil, err.(errors.Error).Wrap("did not pass validation")
 	}
 
 	var (
 		u    *User
 		base *Ref
-		err  *errors.Error
+		err  error
 	)
 
 	if sub.SubmittedBy != "" {
 		u, err = m.FindUserByName(sub.SubmittedBy)
 		if err != nil {
-			return nil, err.Wrap("for use in submission")
+			return nil, err.(errors.Error).Wrap("for use in submission")
 		}
 	}
 
 	if sub.BaseSHA != "" {
 		base, err = m.GetRefByNameAndSHA(sub.Parent, sub.BaseSHA)
 		if err != nil {
-			return nil, err.Wrap("base")
+			return nil, err.(errors.Error).Wrap("base")
 		}
 	}
 
 	head, err := m.GetRefByNameAndSHA(sub.Fork, sub.HeadSHA)
 	if err != nil {
-		return nil, err.Wrap("head")
+		return nil, err.(errors.Error).Wrap("head")
 	}
 
 	return &Submission{
@@ -177,7 +177,7 @@ func (m *Model) NewSubmissionFromMessage(sub *types.Submission) (*Submission, *e
 }
 
 // SubmissionList returns a list of submissions with pagination and repo/sha filtering.
-func (m *Model) SubmissionList(page, perPage int64, repository, sha string) ([]*Submission, *errors.Error) {
+func (m *Model) SubmissionList(page, perPage int64, repository, sha string) ([]*Submission, error) {
 	subs := []*Submission{}
 
 	page, perPage, err := utils.ScopePaginationInt(page, perPage)
@@ -199,7 +199,7 @@ func (m *Model) SubmissionList(page, perPage int64, repository, sha string) ([]*
 }
 
 // SubmissionCount counts the number of submissions with an optional repo/sha filter
-func (m *Model) SubmissionCount(repository, sha string) (int64, *errors.Error) {
+func (m *Model) SubmissionCount(repository, sha string) (int64, error) {
 	var count int64
 
 	obj, err := m.submissionListQuery(repository, sha)
@@ -210,7 +210,7 @@ func (m *Model) SubmissionCount(repository, sha string) (int64, *errors.Error) {
 	return count, m.WrapError(obj.Model(&Submission{}).Count(&count), "listing submissions")
 }
 
-func (m *Model) submissionListQuery(repository, sha string) (*gorm.DB, *errors.Error) {
+func (m *Model) submissionListQuery(repository, sha string) (*gorm.DB, error) {
 	obj := m.Group("submissions.id").Order("submissions.id DESC").
 		Joins("inner join refs on refs.id = submissions.base_ref_id or refs.id = submissions.head_ref_id")
 
@@ -221,7 +221,7 @@ func (m *Model) submissionListQuery(repository, sha string) (*gorm.DB, *errors.E
 		}
 		obj = obj.Where("submissions.base_ref_id = ? or submissions.head_ref_id = ?", ref.ID, ref.ID)
 	} else if repository != "" {
-		var err *errors.Error
+		var err error
 		repo, err := m.GetRepositoryByName(repository)
 		if err != nil {
 			return nil, err
@@ -232,7 +232,7 @@ func (m *Model) submissionListQuery(repository, sha string) (*gorm.DB, *errors.E
 	return obj, nil
 }
 
-func (m *Model) assignCountFromQuery(query string, ids []int64) (map[int64]int64, *errors.Error) {
+func (m *Model) assignCountFromQuery(query string, ids []int64) (map[int64]int64, error) {
 	idmap := map[int64]int64{}
 
 	rows, err := m.Raw(query, ids).Rows()
@@ -253,7 +253,7 @@ func (m *Model) assignCountFromQuery(query string, ids []int64) (map[int64]int64
 	return idmap, nil
 }
 
-func (m *Model) assignSubmissionPostFetch(subs []*Submission) *errors.Error {
+func (m *Model) assignSubmissionPostFetch(subs []*Submission) error {
 	idmap := map[int64]*Submission{}
 	ids := []int64{}
 	for _, sub := range subs {
@@ -295,7 +295,7 @@ func (m *Model) assignSubmissionPostFetch(subs []*Submission) *errors.Error {
 	return m.populateStates(ids, idmap)
 }
 
-func (m *Model) selectOne(query string, id int64, out interface{}) *errors.Error {
+func (m *Model) selectOne(query string, id int64, out interface{}) error {
 	rows, err := m.Raw(query, id).Rows()
 	if err != nil {
 		return errors.New(err)
@@ -311,7 +311,7 @@ func (m *Model) selectOne(query string, id int64, out interface{}) *errors.Error
 	return nil
 }
 
-func (m *Model) gatherStates(ids []int64) (map[int64][]*bool, map[int64]bool, *errors.Error) {
+func (m *Model) gatherStates(ids []int64) (map[int64][]*bool, map[int64]bool, error) {
 	rows, err := m.Raw("select submission_id, status, canceled from tasks where submission_id in (?)", ids).Rows()
 	if err != nil {
 		return nil, nil, errors.New(err)
@@ -348,7 +348,7 @@ func (m *Model) gatherStates(ids []int64) (map[int64][]*bool, map[int64]bool, *e
 	return overallStatus, submissionCanceled, nil
 }
 
-func (m *Model) populateStates(ids []int64, idmap map[int64]*Submission) *errors.Error {
+func (m *Model) populateStates(ids []int64, idmap map[int64]*Submission) error {
 	overallStatus, submissionCanceled, err := m.gatherStates(ids)
 	if err != nil {
 		return err
@@ -395,7 +395,7 @@ func (m *Model) populateStates(ids []int64, idmap map[int64]*Submission) *errors
 
 // SubmissionListForRepository returns a list of submissions with pagination. If ref
 // is non-nil, it will isolate to the ref only and ignore the repo.
-func (m *Model) SubmissionListForRepository(repo, sha string, page, perPage int64) ([]*Submission, *errors.Error) {
+func (m *Model) SubmissionListForRepository(repo, sha string, page, perPage int64) ([]*Submission, error) {
 	subs := []*Submission{}
 
 	page, perPage, err := utils.ScopePaginationInt(page, perPage)
@@ -430,7 +430,7 @@ func (m *Model) submissionRunsQuery(sub *Submission) *gorm.DB {
 }
 
 // TasksForSubmission returns all the tasks for a given submission.
-func (m *Model) TasksForSubmission(sub *Submission, page, perPage int64) ([]*Task, *errors.Error) {
+func (m *Model) TasksForSubmission(sub *Submission, page, perPage int64) ([]*Task, error) {
 	tasks := []*Task{}
 
 	obj := m.submissionTasksQuery(sub).Offset(page * perPage).Limit(perPage)
@@ -442,7 +442,7 @@ func (m *Model) TasksForSubmission(sub *Submission, page, perPage int64) ([]*Tas
 }
 
 // RunsForSubmission returns all the runs that are associated with the given submission.
-func (m *Model) RunsForSubmission(sub *Submission, page, perPage int64) ([]*Run, *errors.Error) {
+func (m *Model) RunsForSubmission(sub *Submission, page, perPage int64) ([]*Run, error) {
 	runs := []*Run{}
 
 	obj := m.submissionRunsQuery(sub).Offset(page * perPage).Limit(perPage)
@@ -454,7 +454,7 @@ func (m *Model) RunsForSubmission(sub *Submission, page, perPage int64) ([]*Run,
 }
 
 // GetSubmissionByID returns a submission by internal identifier
-func (m *Model) GetSubmissionByID(id int64) (*Submission, *errors.Error) {
+func (m *Model) GetSubmissionByID(id int64) (*Submission, error) {
 	sub := &Submission{}
 	if err := m.WrapError(m.Where("submissions.id = ?", id).First(sub), "getting submission by id"); err != nil {
 		return nil, err
@@ -463,7 +463,7 @@ func (m *Model) GetSubmissionByID(id int64) (*Submission, *errors.Error) {
 }
 
 // CancelSubmissionByID cancels all related tasks (and thusly, runs) in a submission that are outstanding.
-func (m *Model) CancelSubmissionByID(id int64, baseURL string, client github.Client) *errors.Error {
+func (m *Model) CancelSubmissionByID(id int64, baseURL string, client github.Client) error {
 	sub, err := m.GetSubmissionByID(id)
 	if err != nil {
 		return err

--- a/model/task_runs.go
+++ b/model/task_runs.go
@@ -6,7 +6,7 @@ import (
 )
 
 // GetRunsForTask is just a join of all runs that belong to a task.
-func (m *Model) GetRunsForTask(id, page, perPage int64) ([]*Run, *errors.Error) {
+func (m *Model) GetRunsForTask(id, page, perPage int64) ([]*Run, error) {
 	runs := []*Run{}
 
 	page, perPage, err := utils.ScopePaginationInt(page, perPage)
@@ -22,7 +22,7 @@ func (m *Model) GetRunsForTask(id, page, perPage int64) ([]*Run, *errors.Error) 
 }
 
 // CountRunsForTask retrieves the total count of runs for the given task.
-func (m *Model) CountRunsForTask(id int64) (int64, *errors.Error) {
+func (m *Model) CountRunsForTask(id int64) (int64, error) {
 	var count int64
 
 	if err := m.Model(&Run{}).Where("task_id = ?", id).Count(&count).Error; err != nil {

--- a/model/token.go
+++ b/model/token.go
@@ -16,22 +16,22 @@ func (m *Model) createToken(name string) ([]byte, string) {
 	return key, base64.URLEncoding.EncodeToString([]byte(encoded))
 }
 
-func (m *Model) unpackToken(token string) (string, []byte, *errors.Error) {
+func (m *Model) unpackToken(token string) (string, []byte, error) {
 	b, err := base64.URLEncoding.DecodeString(token)
 	if err != nil {
-		return "", nil, errors.ErrInvalidAuth.Wrap(err)
+		return "", nil, errors.ErrInvalidAuth.(errors.Error).Wrap(err)
 	}
 
 	parts := strings.SplitN(string(b), " ", 2)
 	if len(parts) != 2 {
-		return "", nil, errors.ErrInvalidAuth.Wrap("invalid token")
+		return "", nil, errors.ErrInvalidAuth.(errors.Error).Wrap("invalid token")
 	}
 
 	return parts[0], []byte(parts[1]), nil
 }
 
 // ValidateToken checks that a token is valid for a given user.
-func (m *Model) ValidateToken(token string) (*User, *errors.Error) {
+func (m *Model) ValidateToken(token string) (*User, error) {
 	name, authToken, err := m.unpackToken(token)
 	if err != nil {
 		return nil, err // except for in this case, where it's done already above.
@@ -56,7 +56,7 @@ func (m *Model) ValidateToken(token string) (*User, *errors.Error) {
 // GetToken retrieves a new token for logging in. If one exists, the
 // DeleteToken method must be called first; otherwise this routine will throw
 // an error.
-func (m *Model) GetToken(name string) (string, *errors.Error) {
+func (m *Model) GetToken(name string) (string, error) {
 	u, err := m.FindUserByName(name)
 	if err != nil {
 		return "", err
@@ -77,7 +77,7 @@ func (m *Model) GetToken(name string) (string, *errors.Error) {
 }
 
 // DeleteToken removes the existing token.
-func (m *Model) DeleteToken(name string) *errors.Error {
+func (m *Model) DeleteToken(name string) error {
 	u, err := m.FindUserByName(name)
 	if err != nil {
 		return err

--- a/model/token_test.go
+++ b/model/token_test.go
@@ -33,5 +33,5 @@ func (ms *modelSuite) TestBasicToken(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(retUser.Username, check.Equals, u.Username)
 	_, err = ms.model.ValidateToken(token)
-	c.Assert(err, check.Equals, errors.ErrInvalidAuth)
+	c.Assert(err, check.DeepEquals, errors.ErrInvalidAuth)
 }

--- a/model/user.go
+++ b/model/user.go
@@ -37,7 +37,7 @@ var (
 	TokenCryptKey = []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}
 )
 
-// UserError is the encapsulation of many *errors.Errors that need to be presented to
+// UserError is the encapsulation of many errors that need to be presented to
 // the user.
 type UserError struct {
 	ID     int64  `gorm:"primary key" json:"id"`
@@ -77,25 +77,25 @@ type User struct {
 }
 
 // SetToken sets the token's byte stream, and encrypts it.
-func (u *User) SetToken() *errors.Error {
-	var err *errors.Error
+func (u *User) SetToken() error {
+	var err error
 	u.TokenJSON, err = topTypes.EncryptToken(TokenCryptKey, u.Token)
 	return err
 }
 
 // FetchToken retrieves the token from the db, decrypting it if necessary.
-func (u *User) FetchToken() *errors.Error {
+func (u *User) FetchToken() error {
 	if u.Token != nil {
 		return nil
 	}
 
-	var err *errors.Error
+	var err error
 	u.Token, err = topTypes.DecryptToken(TokenCryptKey, u.TokenJSON)
 	return err
 }
 
 // NewUserFromProto converts a proto user to a real user.
-func NewUserFromProto(u *types.User) (*User, *errors.Error) {
+func NewUserFromProto(u *types.User) (*User, error) {
 	errs := []UserError{}
 
 	if len(u.Errors) != 0 {
@@ -123,7 +123,7 @@ func NewUserFromProto(u *types.User) (*User, *errors.Error) {
 }
 
 // MakeUsers converts a proto userlist to a model one.
-func MakeUsers(users []*types.User) ([]*User, *errors.Error) {
+func MakeUsers(users []*types.User) ([]*User, error) {
 	ret := []*User{}
 	for _, user := range users {
 		u, err := NewUserFromProto(user)
@@ -168,25 +168,25 @@ func (u *User) ToProto() *types.User {
 }
 
 // CreateUser initializes a user struct and writes it to the db.
-func (m *Model) CreateUser(username string, token *topTypes.OAuthToken) (*User, *errors.Error) {
+func (m *Model) CreateUser(username string, token *topTypes.OAuthToken) (*User, error) {
 	u := &User{Username: username, Token: token}
 	return u, m.WrapError(m.Create(u), "creating user")
 }
 
 // FindUserByID finds the user by integer ID.
-func (m *Model) FindUserByID(id int64) (*User, *errors.Error) {
+func (m *Model) FindUserByID(id int64) (*User, error) {
 	u := &User{}
 	return u, m.WrapError(m.Where("id = ?", id).First(u), "finding user by id")
 }
 
 // FindUserByName finds a user by unique key username.
-func (m *Model) FindUserByName(username string) (*User, *errors.Error) {
+func (m *Model) FindUserByName(username string) (*User, error) {
 	u := &User{}
 	return u, m.WrapError(m.Where("username = ?", username).First(u), "finding user by name")
 }
 
 // FindUserByNameWithSubscriptions finds a user by unique key username. It also fetches the subscriptions for the user.
-func (m *Model) FindUserByNameWithSubscriptions(username, search string) (*User, *errors.Error) {
+func (m *Model) FindUserByNameWithSubscriptions(username, search string) (*User, error) {
 	u := &User{}
 	if search == "" {
 		return u, m.WrapError(m.Preload("Subscribed").Where("username = ?", username).First(u), "preloading subscriptions with user")
@@ -194,24 +194,24 @@ func (m *Model) FindUserByNameWithSubscriptions(username, search string) (*User,
 	return u, m.WrapError(m.Preload("Subscribed", "name like ?", "%"+search+"%").Where("username = ?", username).First(u), "preloading subscriptions with user")
 }
 
-// DeleteError deletes a given *errors.Error for a user.
-func (m *Model) DeleteError(u *User, id int64) *errors.Error {
+// DeleteError deletes a given error for a user.
+func (m *Model) DeleteError(u *User, id int64) error {
 	return m.WrapError(m.Where("id = ?", id).Delete(u.Errors), "deleting errors for user")
 }
 
 // AddSubscriptionsForUser adds the repositories to the subscriptions table. Access is
 // validated at the API level, not here.
-func (m *Model) AddSubscriptionsForUser(u *User, repos []*Repository) *errors.Error {
+func (m *Model) AddSubscriptionsForUser(u *User, repos []*Repository) error {
 	return errors.New(m.Model(u).Association("Subscribed").Append(repos).Error)
 }
 
 // RemoveSubscriptionForUser removes an item from the subscriptions table.
-func (m *Model) RemoveSubscriptionForUser(u *User, repo *Repository) *errors.Error {
+func (m *Model) RemoveSubscriptionForUser(u *User, repo *Repository) error {
 	return errors.New(m.Model(u).Association("Subscribed").Delete(repo).Error)
 }
 
 // AddError adds an error to the error list.
-func (u *User) AddError(err *errors.Error) {
+func (u *User) AddError(err error) {
 	u.Errors = append(u.Errors, UserError{Error: err.Error()})
 }
 
@@ -222,7 +222,7 @@ func (u *User) AfterFind(tx *gorm.DB) error {
 	}
 
 	if err := u.Validate(); err != nil {
-		return errors.New(err).Wrapf("reading user id %d (%q)", u.ID, u.Username)
+		return errors.New(err).(errors.Error).Wrapf("reading user id %d (%q)", u.ID, u.Username)
 	}
 
 	return nil
@@ -236,7 +236,7 @@ func (u *User) BeforeCreate(tx *gorm.DB) error {
 // BeforeSave is a gorm hook to marshal the Token JSON before saving the record
 func (u *User) BeforeSave(tx *gorm.DB) error {
 	if err := u.ValidateWrite(); err != nil {
-		return errors.New(err).Wrapf("saving user %q", u.Username)
+		return errors.New(err).(errors.Error).Wrapf("saving user %q", u.Username)
 	}
 
 	if err := u.SetToken(); err != nil {
@@ -247,7 +247,7 @@ func (u *User) BeforeSave(tx *gorm.DB) error {
 }
 
 // ValidateWrite is for write-only validations.
-func (u *User) ValidateWrite() *errors.Error {
+func (u *User) ValidateWrite() error {
 	if u.Token == nil || u.Token.Token == "" {
 		return errors.New("cannot be written because the oauth credentials are not valid")
 	}
@@ -256,7 +256,7 @@ func (u *User) ValidateWrite() *errors.Error {
 }
 
 // Validate validates the user record to ensure it can be written.
-func (u *User) Validate() *errors.Error {
+func (u *User) Validate() error {
 	if u.Username == "" {
 		return errors.New("username is empty")
 	}
@@ -277,7 +277,7 @@ func (m *Model) mkRepositoryFromGithub(repo *gh.Repository, owner *User, autoCre
 
 // SaveRepositories saves github repositories; it sets the *User provided to
 // the owner of it.
-func (m *Model) SaveRepositories(repos []*gh.Repository, username string, autoCreated bool) *errors.Error {
+func (m *Model) SaveRepositories(repos []*gh.Repository, username string, autoCreated bool) error {
 	owner, err := m.FindUserByName(username)
 	if err != nil {
 		return err
@@ -288,7 +288,7 @@ func (m *Model) SaveRepositories(repos []*gh.Repository, username string, autoCr
 		if err != nil {
 			localRepo := m.mkRepositoryFromGithub(repo, owner, autoCreated)
 			if err := m.WrapError(m.Create(localRepo), "creating repository"); err != nil {
-				return err.Wrapf("could not create repository %q", repo.GetFullName())
+				return err.(errors.Error).Wrapf("could not create repository %q", repo.GetFullName())
 			}
 		}
 	}
@@ -301,7 +301,7 @@ func (m *Model) SaveRepositories(repos []*gh.Repository, username string, autoCr
 
 // ListSubscribedTasksForUser lists all tasks related to the subscribed repositories
 // for the user.
-func (m *Model) ListSubscribedTasksForUser(userID, page, perPage int64) ([]*Task, *errors.Error) {
+func (m *Model) ListSubscribedTasksForUser(userID, page, perPage int64) ([]*Task, error) {
 	tasks := []*Task{}
 	call := m.Limit(perPage).Offset(page*perPage).
 		Joins("inner join submissions on submissions.id = tasks.submission_id").
@@ -313,17 +313,17 @@ func (m *Model) ListSubscribedTasksForUser(userID, page, perPage int64) ([]*Task
 }
 
 // AddCapabilityToUser adds a capability to a user account.
-func (m *Model) AddCapabilityToUser(u *User, cap Capability) *errors.Error {
+func (m *Model) AddCapabilityToUser(u *User, cap Capability) error {
 	return m.WrapError(m.Exec("insert into user_capabilities (user_id, name) values (?, ?)", u.ID, cap), "adding capability for user")
 }
 
 // RemoveCapabilityFromUser removes a capability from a user account.
-func (m *Model) RemoveCapabilityFromUser(u *User, cap Capability) *errors.Error {
+func (m *Model) RemoveCapabilityFromUser(u *User, cap Capability) error {
 	return m.WrapError(m.Exec("delete from user_capabilities where user_id = ? and name = ?", u.ID, cap), "removing capability from user")
 }
 
 // GetCapabilities returns the capabilities the supplied user account has.
-func (m *Model) GetCapabilities(u *User, fixedCaps map[string][]string) ([]Capability, *errors.Error) {
+func (m *Model) GetCapabilities(u *User, fixedCaps map[string][]string) ([]Capability, error) {
 	caps := map[string]struct{}{}
 
 	if fc, ok := fixedCaps[u.Username]; ok {
@@ -354,7 +354,7 @@ func (m *Model) GetCapabilities(u *User, fixedCaps map[string][]string) ([]Capab
 }
 
 // HasCapability returns true if the user is capable of performing the operation.
-func (m *Model) HasCapability(u *User, cap Capability, fixedCaps map[string][]string) (bool, *errors.Error) {
+func (m *Model) HasCapability(u *User, cap Capability, fixedCaps map[string][]string) (bool, error) {
 	// if we have fixed caps, we consult that table only; these are overrides for
 	// users that exist within the configuration file for the datasvc.
 	if caps, ok := fixedCaps[u.Username]; ok {

--- a/model/utils_for_test.go
+++ b/model/utils_for_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tinyci/ci-agents/types"
 )
 
-func (ms *modelSuite) CreateRef(r *Repository, name, sha string) (*Ref, *errors.Error) {
+func (ms *modelSuite) CreateRef(r *Repository, name, sha string) (*Ref, error) {
 	ref := &Ref{
 		Repository: r,
 		SHA:        sha,
@@ -22,7 +22,7 @@ func (ms *modelSuite) CreateRef(r *Repository, name, sha string) (*Ref, *errors.
 }
 
 // CreateUsers creates `count` random users.
-func (ms *modelSuite) CreateUsers(count int) ([]*User, *errors.Error) {
+func (ms *modelSuite) CreateUsers(count int) ([]*User, error) {
 	users := []*User{}
 
 	for i := 0; i < count; i++ {
@@ -38,11 +38,11 @@ func (ms *modelSuite) CreateUsers(count int) ([]*User, *errors.Error) {
 }
 
 // CreateRepository creates a random repository.
-func (ms *modelSuite) CreateRepository() (*Repository, *errors.Error) {
+func (ms *modelSuite) CreateRepository() (*Repository, error) {
 	return ms.CreateRepositoryWithName(path.Join(testutil.RandString(8), testutil.RandString(8)))
 }
 
-func (ms *modelSuite) CreateRepositoryWithName(name string) (*Repository, *errors.Error) {
+func (ms *modelSuite) CreateRepositoryWithName(name string) (*Repository, error) {
 	owners, err := ms.CreateUsers(1)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func (ms *modelSuite) CreateRepositoryWithName(name string) (*Repository, *error
 	return r, errors.New(ms.model.Save(r).Error)
 }
 
-func (ms *modelSuite) CreateTaskForSubmission(sub *Submission) (*Task, *errors.Error) {
+func (ms *modelSuite) CreateTaskForSubmission(sub *Submission) (*Task, error) {
 	ts := &types.TaskSettings{
 		Mountpoint: "/tmp",
 		Runs: map[string]*types.RunSettings{
@@ -95,7 +95,7 @@ func (ms *modelSuite) CreateTaskForSubmission(sub *Submission) (*Task, *errors.E
 	return run.Task, nil
 }
 
-func (ms *modelSuite) CreateRun() (*Run, *errors.Error) {
+func (ms *modelSuite) CreateRun() (*Run, error) {
 	parent, err := ms.CreateRepository()
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ func (ms *modelSuite) CreateRun() (*Run, *errors.Error) {
 	return run, errors.New(ms.model.Save(run).Error)
 }
 
-func (ms *modelSuite) FillQueue(count int64) ([]*QueueItem, *errors.Error) {
+func (ms *modelSuite) FillQueue(count int64) ([]*QueueItem, error) {
 	fillstart := time.Now()
 	qis := []*QueueItem{}
 
@@ -176,7 +176,7 @@ func (ms *modelSuite) FillQueue(count int64) ([]*QueueItem, *errors.Error) {
 		qis = append(qis, qi)
 	}
 
-	var err *errors.Error
+	var err error
 	qis, err = ms.model.QueuePipelineAdd(qis)
 	if err != nil {
 		return nil, err
@@ -187,7 +187,7 @@ func (ms *modelSuite) FillQueue(count int64) ([]*QueueItem, *errors.Error) {
 	return qis, nil
 }
 
-func (ms *modelSuite) CreateSubmission(sub *types.Submission) (*Submission, *errors.Error) {
+func (ms *modelSuite) CreateSubmission(sub *types.Submission) (*Submission, error) {
 	if sub.SubmittedBy != "" {
 		if _, err := ms.model.CreateUser(sub.SubmittedBy, testutil.DummyToken); err != nil {
 			return nil, err

--- a/testutil/cmd/tinyci-fixturegen/main.go
+++ b/testutil/cmd/tinyci-fixturegen/main.go
@@ -98,7 +98,7 @@ func main() {
 	app.Action = generate
 
 	if err := app.Run(os.Args); err != nil {
-		errors.New(err).Exit()
+		errors.New(err).(errors.Error).Exit()
 	}
 }
 
@@ -106,7 +106,7 @@ func (c *cmd) getString() string {
 	return testutil.RandString(rand.Intn(c.max-c.min) + c.min)
 }
 
-func (c *cmd) mkUsers() ([]*model.User, *errors.Error) {
+func (c *cmd) mkUsers() ([]*model.User, error) {
 	users := []*model.User{}
 
 	for i := rand.Intn(int(c.ctx.GlobalUint("owners"))) + 1; i >= 0; i-- {
@@ -121,7 +121,7 @@ func (c *cmd) mkUsers() ([]*model.User, *errors.Error) {
 	return users, nil
 }
 
-func (c *cmd) mkParents(ctx context.Context, users []*model.User) (model.RepositoryList, *errors.Error) {
+func (c *cmd) mkParents(ctx context.Context, users []*model.User) (model.RepositoryList, error) {
 	parents := model.RepositoryList{}
 
 	for i := rand.Intn(int(c.ctx.GlobalUint("repositories"))) + 1; i >= 0; i-- {
@@ -148,7 +148,7 @@ func (c *cmd) mkParents(ctx context.Context, users []*model.User) (model.Reposit
 	return parents, nil
 }
 
-func (c *cmd) mkForks(ctx context.Context, users []*model.User, parents model.RepositoryList) (map[string]*model.Repository, *errors.Error) {
+func (c *cmd) mkForks(ctx context.Context, users []*model.User, parents model.RepositoryList) (map[string]*model.Repository, error) {
 	forkParents := map[string]*model.Repository{}
 
 	for i := rand.Intn(int(c.ctx.GlobalUint("forks"))) + 1; i >= 0; i-- {
@@ -187,7 +187,7 @@ func (c *cmd) mkForks(ctx context.Context, users []*model.User, parents model.Re
 	return forkParents, nil
 }
 
-func (c *cmd) mkRefs(ctx context.Context, forkParents map[string]*model.Repository) ([]*model.Ref, []*model.Ref, *errors.Error) {
+func (c *cmd) mkRefs(ctx context.Context, forkParents map[string]*model.Repository) ([]*model.Ref, []*model.Ref, error) {
 	headrefs := []*model.Ref{}
 	baserefs := []*model.Ref{}
 
@@ -242,7 +242,7 @@ func (c *cmd) mkRefs(ctx context.Context, forkParents map[string]*model.Reposito
 	return headrefs, baserefs, nil
 }
 
-func (c *cmd) mkTask(ctx context.Context, sub *model.Submission) (*model.Task, *errors.Error) {
+func (c *cmd) mkTask(ctx context.Context, sub *model.Submission) (*model.Task, error) {
 	started := rand.Intn(2) == 0
 	finished := started && rand.Intn(2) == 0
 
@@ -283,7 +283,7 @@ func (c *cmd) mkTask(ctx context.Context, sub *model.Submission) (*model.Task, *
 	return c.dc.Client().PutTask(ctx, task)
 }
 
-func (c *cmd) mkTasks(ctx context.Context, subs []*model.Submission) *errors.Error {
+func (c *cmd) mkTasks(ctx context.Context, subs []*model.Submission) error {
 	for _, sub := range subs {
 		for taskC := rand.Intn(int(c.ctx.GlobalUint("tasks"))) + 1; taskC >= 0; taskC-- {
 			task, err := c.mkTask(ctx, sub)
@@ -314,7 +314,7 @@ func (c *cmd) mkTasks(ctx context.Context, subs []*model.Submission) *errors.Err
 	return nil
 }
 
-func (c *cmd) mkSubmissions(ctx context.Context, u *model.User, baserefs []*model.Ref, headrefs []*model.Ref) ([]*model.Submission, *errors.Error) {
+func (c *cmd) mkSubmissions(ctx context.Context, u *model.User, baserefs []*model.Ref, headrefs []*model.Ref) ([]*model.Submission, error) {
 	if len(headrefs) != len(baserefs) {
 		return nil, errors.New("refs count is not equal")
 	}
@@ -328,7 +328,7 @@ func (c *cmd) mkSubmissions(ctx context.Context, u *model.User, baserefs []*mode
 			User:    u,
 		}
 
-		var err *errors.Error
+		var err error
 		sub, err = c.dc.Client().PutSubmission(ctx, sub)
 		if err != nil {
 			return nil, err

--- a/testutil/testclients/datasvc.go
+++ b/testutil/testclients/datasvc.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/go-github/github"
 	"github.com/tinyci/ci-agents/clients/data"
 	"github.com/tinyci/ci-agents/config"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/model"
 	"github.com/tinyci/ci-agents/testutil"
 	"github.com/tinyci/ci-agents/types"
@@ -20,7 +19,7 @@ type DataClient struct {
 }
 
 // NewDataClient returns a new datasvc client with window dressings for tests.
-func NewDataClient() (*DataClient, *errors.Error) {
+func NewDataClient() (*DataClient, error) {
 	ops, err := data.New(config.DefaultServices.Data.String(), nil, false)
 	return &DataClient{client: ops}, err
 }
@@ -31,7 +30,7 @@ func (dc *DataClient) Client() *data.Client {
 }
 
 // MakeUser makes a new user with the name provided. It is given a dummy access token.
-func (dc *DataClient) MakeUser(username string) (*model.User, *errors.Error) {
+func (dc *DataClient) MakeUser(username string) (*model.User, error) {
 	return dc.client.PutUser(context.Background(), &model.User{
 		Username: username,
 		Token:    testutil.DummyToken,
@@ -39,7 +38,7 @@ func (dc *DataClient) MakeUser(username string) (*model.User, *errors.Error) {
 }
 
 // MakeRepo saves a repo with name, owner, and private state.
-func (dc *DataClient) MakeRepo(fullRepo, owner string, private bool, forkOf string) *errors.Error {
+func (dc *DataClient) MakeRepo(fullRepo, owner string, private bool, forkOf string) error {
 	repos := []interface{}{
 		map[string]interface{}{"full_name": fullRepo, "private": private},
 	}
@@ -61,7 +60,7 @@ func (dc *DataClient) MakeRepo(fullRepo, owner string, private bool, forkOf stri
 }
 
 // MakeQueueItem returns a queueitem that has already been stored
-func (dc *DataClient) MakeQueueItem() (*model.QueueItem, *errors.Error) {
+func (dc *DataClient) MakeQueueItem() (*model.QueueItem, error) {
 	username := testutil.RandString(8)
 	_, err := dc.MakeUser(username)
 	if err != nil {

--- a/testutil/testclients/queuesvc.go
+++ b/testutil/testclients/queuesvc.go
@@ -10,7 +10,6 @@ import (
 	gh "github.com/google/go-github/github"
 	"github.com/tinyci/ci-agents/clients/queue"
 	"github.com/tinyci/ci-agents/config"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/mocks/github"
 	"github.com/tinyci/ci-agents/types"
 	"github.com/tinyci/ci-agents/utils"
@@ -35,7 +34,7 @@ func (qc *QueueClient) Client() *queue.Client {
 
 // SetUpSubmissionRepo takes a name of a repo; and configures the submission
 // repo and a user belonging to it. Returns the name of the owner and any error.
-func (qc *QueueClient) SetUpSubmissionRepo(name string, forkOf string) *errors.Error {
+func (qc *QueueClient) SetUpSubmissionRepo(name string, forkOf string) error {
 	parentUser, _, err := utils.OwnerRepo(name)
 	if err != nil {
 		return err

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -8,7 +8,6 @@ import (
 
 	check "github.com/erikh/check"
 	"github.com/jinzhu/gorm"
-	"github.com/tinyci/ci-agents/errors"
 	"github.com/tinyci/ci-agents/types"
 	"github.com/tinyci/ci-agents/utils"
 )
@@ -75,6 +74,6 @@ func RandString(len int) string {
 
 // JSONIO uses json serialization to convert from one struct to another
 // p.s. this is terrible
-func JSONIO(from, to interface{}) *errors.Error {
+func JSONIO(from, to interface{}) error {
 	return utils.JSONIO(from, to)
 }

--- a/types/submission.go
+++ b/types/submission.go
@@ -19,7 +19,7 @@ type Submission struct {
 }
 
 // Validate validates the submission, and returns an error if it encounters any.
-func (sub *Submission) Validate() *errors.Error {
+func (sub *Submission) Validate() error {
 	if !sub.Manual && !utils.IsOwnerRepo(sub.Parent) {
 		return errors.New("parent is invalid")
 	}
@@ -37,7 +37,7 @@ func (sub *Submission) Validate() *errors.Error {
 	}
 
 	if !utils.IsSHA(sub.HeadSHA) {
-		var err *errors.Error
+		var err error
 		sub.HeadSHA, err = utils.QualifyBranch(sub.HeadSHA)
 		if err != nil {
 			return err
@@ -47,7 +47,7 @@ func (sub *Submission) Validate() *errors.Error {
 	if sub.BaseSHA == "" && !sub.Manual {
 		return errors.New("base sha is empty")
 	} else if !sub.Manual && !utils.IsSHA(sub.BaseSHA) {
-		var err *errors.Error
+		var err error
 		sub.BaseSHA, err = utils.QualifyBranch(sub.BaseSHA)
 		if err != nil {
 			return err

--- a/types/task.go
+++ b/types/task.go
@@ -94,7 +94,7 @@ func (t *TaskSettings) ToProto() *types.TaskSettings {
 }
 
 // NewTaskSettings creates a new task configuration from a byte buffer.
-func NewTaskSettings(buf []byte, requireRuns bool, rc *RepoConfig) (*TaskSettings, *errors.Error) {
+func NewTaskSettings(buf []byte, requireRuns bool, rc *RepoConfig) (*TaskSettings, error) {
 	if rc == nil {
 		rc = &RepoConfig{}
 	}
@@ -102,13 +102,13 @@ func NewTaskSettings(buf []byte, requireRuns bool, rc *RepoConfig) (*TaskSetting
 	t := &TaskSettings{}
 
 	if err := yaml.UnmarshalStrict(buf, t); err != nil {
-		return nil, errors.New(err).Wrap(ErrTaskParse)
+		return nil, errors.New(err).(errors.Error).Wrap(ErrTaskParse)
 	}
 
 	t.Config = rc
 
 	if err := t.Validate(requireRuns); err != nil {
-		return nil, errors.New(err).Wrap(ErrTaskValidation)
+		return nil, errors.New(err).(errors.Error).Wrap(ErrTaskValidation)
 	}
 
 	return t, nil
@@ -188,7 +188,7 @@ func (t *TaskSettings) handleOverrides() {
 }
 
 // Validate validates the task settings.
-func (t *TaskSettings) Validate(requireRuns bool) *errors.Error {
+func (t *TaskSettings) Validate(requireRuns bool) error {
 	if t.Config == nil {
 		t.Config = &RepoConfig{}
 	}
@@ -253,8 +253,8 @@ func (rs *RunSettings) ToProto() *types.RunSettings {
 	}
 }
 
-// Validate validates the run settings, returning *errors.Errors on any found.
-func (rs *RunSettings) Validate() *errors.Error {
+// Validate validates the run settings, returning errors on any found.
+func (rs *RunSettings) Validate() error {
 	if len(rs.Command) == 0 {
 		return errors.New("command was empty")
 	}
@@ -287,7 +287,7 @@ type RepoConfig struct {
 }
 
 // NewRepoConfig creates a new repo config from a byte buffer.
-func NewRepoConfig(buf []byte) (*RepoConfig, *errors.Error) {
+func NewRepoConfig(buf []byte) (*RepoConfig, error) {
 	r := &RepoConfig{}
 
 	if err := yaml.UnmarshalStrict(buf, r); err != nil {
@@ -305,8 +305,8 @@ func (r *RepoConfig) handleOverrides() {
 	}
 }
 
-// Validate returns any *errors.Error if there are validation *errors.Errors in the repo config.
-func (r *RepoConfig) Validate() *errors.Error {
+// Validate returns any error if there are validation errors in the repo config.
+func (r *RepoConfig) Validate() error {
 	// it doesn't do much right now..
 	if r.Queue == "" {
 		return errors.New("queue was empty")

--- a/utils/json.go
+++ b/utils/json.go
@@ -9,7 +9,7 @@ import (
 )
 
 // JSONIO is a copy function that uses JSON as an intermediary.
-func JSONIO(from, to interface{}) *errors.Error {
+func JSONIO(from, to interface{}) error {
 	// Yes. I know it sucks. I blame go-swagger.
 	content, err := json.Marshal(from)
 	if err != nil {
@@ -20,7 +20,7 @@ func JSONIO(from, to interface{}) *errors.Error {
 }
 
 // JSONContext provides an easy method to extract json from gin parameters.
-func JSONContext(ctx *gin.Context, parameter string, obj interface{}) *errors.Error {
+func JSONContext(ctx *gin.Context, parameter string, obj interface{}) error {
 	content, ok := ctx.Get(parameter)
 	if !ok {
 		return errors.New(fmt.Sprintf("parameter %q not found", parameter))

--- a/utils/pagination.go
+++ b/utils/pagination.go
@@ -13,7 +13,7 @@ const defaultPerPage int64 = 10
 
 // ScopePaginationInt applies constraints to pagination; it sets a maximum and a
 // default if not supplied to perPage. Integer-only version.
-func ScopePaginationInt(page, perPage int64) (int64, int64, *errors.Error) {
+func ScopePaginationInt(page, perPage int64) (int64, int64, error) {
 	if page < 0 {
 		return 0, 0, errors.New("invalid page")
 	}
@@ -35,7 +35,7 @@ func ScopePaginationInt(page, perPage int64) (int64, int64, *errors.Error) {
 
 // ScopePagination applies constraints to pagination; it sets a maximum and a
 // default if not supplied to perPage. String version.
-func ScopePagination(pg, ppg string) (int64, int64, *errors.Error) {
+func ScopePagination(pg, ppg string) (int64, int64, error) {
 	var (
 		err           error
 		page, perPage int64

--- a/utils/repository.go
+++ b/utils/repository.go
@@ -13,8 +13,8 @@ var (
 )
 
 // OwnerRepo returns the owner and repository parts of a github full repository
-// name. It returns an *errors.Error if there are issues.
-func OwnerRepo(repoName string) (string, string, *errors.Error) {
+// name. It returns an error if there are issues.
+func OwnerRepo(repoName string) (string, string, error) {
 	parts := strings.Split(repoName, "/")
 	if len(parts) != 2 {
 		return "", "", errors.New("parsing repository name: invalid number of parts")
@@ -64,8 +64,8 @@ func IsSHA(sha string) bool {
 }
 
 // QualifyBranch corrects branch data to reflect our internal ref-type/ref-name
-// strategy for tracking branches. It returns an *errors.Error when it can't figure it out.
-func QualifyBranch(branch string) (string, *errors.Error) {
+// strategy for tracking branches. It returns an error when it can't figure it out.
+func QualifyBranch(branch string) (string, error) {
 	if IsSHA(branch) {
 		return branch, errors.New("is not a branch; is a sha")
 	}

--- a/utils/tracer.go
+++ b/utils/tracer.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func getConfig() (*config.Configuration, *errors.Error) {
+func getConfig() (*config.Configuration, error) {
 	// FIXME Taken from jaeger/opentracing examples; needs tunables.
 	cfg, err := config.FromEnv()
 	if err != nil {
@@ -25,7 +25,7 @@ func getConfig() (*config.Configuration, *errors.Error) {
 }
 
 // CreateTracer creates an opentracing-compatible jaegertracing client.
-func CreateTracer(serviceName string) (io.Closer, *errors.Error) {
+func CreateTracer(serviceName string) (io.Closer, error) {
 	cfg, eErr := getConfig()
 	if eErr != nil {
 		return nil, eErr
@@ -40,7 +40,7 @@ func CreateTracer(serviceName string) (io.Closer, *errors.Error) {
 }
 
 // SetUpGRPCTracing configures grpc dial functions for tracing.
-func SetUpGRPCTracing(client string) (io.Closer, []grpc.DialOption, *errors.Error) {
+func SetUpGRPCTracing(client string) (io.Closer, []grpc.DialOption, error) {
 	cfg, eErr := getConfig()
 	if eErr != nil {
 		return nil, nil, eErr


### PR DESCRIPTION
This patch probably needs a second pass, but this works for now. In
particular, the errors.Error assertions are unwieldy -- the API will
need to change.

This change removes the pointer designation from *errors.Error to be
errors.Error, relying on the interface value of `error` to be nil for
our purposes.

This is much more idiomatic within the go ecosystem and things play
nicer as a result.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
