### PR TITLE
Limit jaeger traces in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     network_mode: "bridge"
     image: jaegertracing/all-in-one:1.8 
     # XXX uncomment if you need to debug your jaeger setup
-    #command: --log-level debug
+    command: --memory.max-traces 10000
     ports:
       - 16686:16686
   tinyci:


### PR DESCRIPTION
will eventually run the machine out of ram. Software.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
