### PR TITLE
Remove explicit master branch references in code, support testing off default branch github API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,10 @@ release: distclean dist
 demo: build-demo-image
 	docker-compose up
 
-clean-demo: build-demo-image
+stop-demo:
+	docker-compose rm -f
+
+clean-demo: build-demo-image stop-demo
 	$(DOCKER_RUN) --entrypoint /bin/bash -v ${PWD}/.ca:/var/ca -v ${PWD}/.logs:/var/tinyci/logs -v ${PWD}/.db:/var/lib/postgresql $(DEMO_DOCKER_IMAGE) -c "rm -rf /var/lib/postgresql/11; rm -rf /var/tinyci/logs/*; rm -rf /var/ca/*"
 
 build-demo-image: get-box

--- a/api/datasvc/basic_test.go
+++ b/api/datasvc/basic_test.go
@@ -229,7 +229,7 @@ func (ds *datasvcSuite) TestSubscriptions(c *check.C) {
 }
 
 func (ds *datasvcSuite) TestRuns(c *check.C) {
-	config.SetDefaultGithubClient(github.NewMockClient(gomock.NewController(c)))
+	config.SetDefaultGithubClient(github.NewMockClient(gomock.NewController(c)), "")
 	now := time.Now()
 	qis := []*model.QueueItem{}
 	for i := 0; i < 1000; i++ {
@@ -271,7 +271,7 @@ func (ds *datasvcSuite) TestRuns(c *check.C) {
 }
 
 func (ds *datasvcSuite) TestQueue(c *check.C) {
-	config.SetDefaultGithubClient(github.NewMockClient(gomock.NewController(c)))
+	config.SetDefaultGithubClient(github.NewMockClient(gomock.NewController(c)), "")
 	now := time.Now()
 	for i := 0; i < 1000; i++ {
 		_, err := ds.client.MakeQueueItem()

--- a/api/datasvc/queue.go
+++ b/api/datasvc/queue.go
@@ -113,7 +113,7 @@ func (ds *DataServer) QueueNext(ctx context.Context, r *types.QueueRequest) (*ty
 
 // PutStatus sets the status for the given run_id
 func (ds *DataServer) PutStatus(ctx context.Context, s *types.Status) (*empty.Empty, error) {
-	if err := ds.H.Model.SetRunStatus(s.Id, config.DefaultGithubClient(), s.Status, false, ds.H.URL, s.AdditionalMessage); err != nil {
+	if err := ds.H.Model.SetRunStatus(s.Id, config.DefaultGithubClient(""), s.Status, false, ds.H.URL, s.AdditionalMessage); err != nil {
 		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 
@@ -123,7 +123,7 @@ func (ds *DataServer) PutStatus(ctx context.Context, s *types.Status) (*empty.Em
 // SetCancel flags the run (which will flag the rest of the task's runs) as
 // canceled. Will fail on finished tasks.
 func (ds *DataServer) SetCancel(ctx context.Context, id *types.IntID) (*empty.Empty, error) {
-	if err := ds.H.Model.CancelRun(id.ID, ds.H.URL, config.DefaultGithubClient()); err != nil {
+	if err := ds.H.Model.CancelRun(id.ID, ds.H.URL, config.DefaultGithubClient("")); err != nil {
 		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 

--- a/api/datasvc/ref.go
+++ b/api/datasvc/ref.go
@@ -39,7 +39,7 @@ func (ds *DataServer) PutRef(ctx context.Context, ref *types.Ref) (*types.Ref, e
 // up by ref and repository information. It is used by the queuesvc to auto
 // cancel runs as new ones are being submitted.
 func (ds *DataServer) CancelRefByName(ctx context.Context, rr *data.RepoRef) (*empty.Empty, error) {
-	if err := ds.H.Model.CancelRefByName(rr.Repository, rr.RefName, ds.H.URL, config.DefaultGithubClient()); err != nil {
+	if err := ds.H.Model.CancelRefByName(rr.Repository, rr.RefName, ds.H.URL, config.DefaultGithubClient("")); err != nil {
 		return nil, err.(errors.Error).ToGRPC(codes.FailedPrecondition)
 	}
 

--- a/api/queuesvc/setup_test.go
+++ b/api/queuesvc/setup_test.go
@@ -68,5 +68,5 @@ func (qs *queuesvcSuite) TearDownTest(c *check.C) {
 }
 
 func (qs *queuesvcSuite) mkGithubClient(client *github.MockClient) {
-	config.SetDefaultGithubClient(client)
+	config.SetDefaultGithubClient(client, "")
 }

--- a/api/queuesvc/task_picker.go
+++ b/api/queuesvc/task_picker.go
@@ -26,17 +26,12 @@ func (sp *submissionProcessor) newTaskPicker() *taskPicker {
 func (tp *taskPicker) pick(ctx context.Context, sub *types.Submission, repoInfo *repoInfo) ([]*model.QueueItem, error) {
 	process := map[string]struct{}{}
 
-	mb := repoInfo.parent.Github.GetMasterBranch()
-	if mb == "" {
-		mb = defaultMasterBranch
-	}
-
 	dirs, taskdirs, err := tp.toProcess(ctx, repoInfo)
 	if err != nil {
 		return nil, err.(errors.Error).Wrap("determining what to process")
 	}
 
-	if (sub.All && sub.Manual) || (repoInfo.forkRef.Repository.ID == repoInfo.parent.ID && repoInfo.parentRef.RefName == mb) {
+	if (sub.All && sub.Manual) || (repoInfo.forkRef.Repository.ID == repoInfo.parent.ID && repoInfo.parentRef.RefName == repoInfo.mainBranch()) {
 		for _, dir := range taskdirs {
 			process[dir] = struct{}{}
 		}

--- a/api/uisvc/restapi/testserver.go
+++ b/api/uisvc/restapi/testserver.go
@@ -45,14 +45,14 @@ func MakeUIServer(client github.Client) (*handlers.H, chan struct{}, *tinyci.Cli
 		return nil, nil, nil, nil, errors.New(err)
 	}
 
-	config.SetDefaultGithubClient(client)
+	config.SetDefaultGithubClient(client, "")
 	finished := make(chan struct{})
 	doneChan, err := handlers.Boot(nil, h, finished)
 	if err != nil {
 		return nil, nil, nil, nil, errors.New(err)
 	}
 
-	u, err := d.PutUser(context.Background(), &model.User{Username: "erikh", Token: &types.OAuthToken{Token: "dummy", Scopes: []string{"repo"}}})
+	u, err := d.PutUser(context.Background(), &model.User{Username: "erikh", Token: &types.OAuthToken{Username: "erikh", Token: "dummy", Scopes: []string{"repo"}}})
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -81,6 +81,8 @@ func MakeUIServer(client github.Client) (*handlers.H, chan struct{}, *tinyci.Cli
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
+
+	config.SetDefaultGithubClient(client, "")
 
 	token, err = d.GetToken(context.Background(), "erikh2")
 	if err != nil {

--- a/config/oauth.go
+++ b/config/oauth.go
@@ -51,23 +51,31 @@ func (oc OAuthConfig) Validate() error {
 
 // SetDefaultGithubClient sets the default github client which is necessary for
 // many testing scenarios. Not to be used in typical code.
-func SetDefaultGithubClient(client github.Client) {
+func SetDefaultGithubClient(client github.Client, username string) {
+	if username == "" {
+		username = "default"
+	}
+
 	githubClientMutex.Lock()
 	defer githubClientMutex.Unlock()
-	defaultGithubClient = client
+	defaultGithubClientMap[username] = client
 }
 
 // DefaultGithubClient returns the default github client set by SetDefaultGithubClient, if any.
-func DefaultGithubClient() github.Client {
+func DefaultGithubClient(username string) github.Client {
 	githubClientMutex.RLock()
 	defer githubClientMutex.RUnlock()
-	return defaultGithubClient
+
+	if username == "" {
+		username = "default"
+	}
+
+	return defaultGithubClientMap[username]
 }
 
-// GithubClient either returns the client for the token, or if NoAuth is set
-// returns the default client.
+// GithubClient either returns the client for the token.
 func (oc OAuthConfig) GithubClient(token *types.OAuthToken) github.Client {
-	client := DefaultGithubClient()
+	client := DefaultGithubClient(token.Username)
 	if client != nil {
 		return client
 	}

--- a/config/service.go
+++ b/config/service.go
@@ -18,8 +18,8 @@ import (
 
 var (
 	// DefaultGithubClient if set, will override any requested github client.
-	defaultGithubClient github.Client
-	githubClientMutex   sync.RWMutex
+	defaultGithubClientMap = map[string]github.Client{}
+	githubClientMutex      = sync.RWMutex{}
 )
 
 // TestClientConfig is a default test client configuration

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/golangci/golangci-lint v1.18.0 // indirect
 	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-github/v32 v32.0.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/securecookie v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,7 @@ github.com/erikh/check v0.0.1 h1:xHG+WX24wCrwqOU1GCt+FMNw2737VlvIhfU7uaNl6TU=
 github.com/erikh/check v0.0.1/go.mod h1:sJqm6NUjmxrVzTAq93B/vvfjih+O20MarQXJmtT3UWA=
 github.com/erikh/go-transport v0.1.0 h1:+5hgJ54QdjhwBBbMLalLd8KdbR7lsyx+k9HBEfml3rY=
 github.com/erikh/go-transport v0.1.0/go.mod h1:m+4kPRT/J3XZlWf8wI7F94qsigCe5Snc3KxAblRkEMw=
+github.com/erikh/migrator v0.0.0-20190428125507-88eb9a06f5e8 h1:BgfVQ4ac3xgQUSDAex1oc1W1mHYBIAKRf97WJoWKnVI=
 github.com/erikh/migrator v0.0.0-20190428125507-88eb9a06f5e8/go.mod h1:zFtL8zXPIG6tKtTx36P6S5j8v4Y0QcJnjl2Yti5HfPY=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -238,6 +239,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v32 v32.0.0 h1:q74KVb22spUq0U5HqZ9VCYqQz8YRuOtL/39ZnfwO+NM=
+github.com/google/go-github/v32 v32.0.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -264,6 +267,7 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jackc/pgx v3.2.0+incompatible h1:0Vihzu20St42/UDsvZGdNE6jak7oi/UOeMzwMPHkgFY=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/gorm v1.9.14 h1:Kg3ShyTPcM6nzVo148fRrcMO6MNKuqtOUwnzqMgVniM=
@@ -463,6 +467,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/model/ref.go
+++ b/model/ref.go
@@ -119,8 +119,8 @@ func (m *Model) CancelRefByName(repoID int64, refName, baseURL string, gh github
 		return errors.New(err)
 	}
 
-	mb := repo.Github.GetMasterBranch()
-	if refName == mb || (mb == "" && refName == "heads/master") {
+	mb := repo.Github.GetDefaultBranch()
+	if refName == mb || (mb == "" && refName == "heads/master") { // FIXME constantize this reference.
 		return nil
 	}
 

--- a/testutil/testclients/queuesvc.go
+++ b/testutil/testclients/queuesvc.go
@@ -67,6 +67,10 @@ func (qc *QueueClient) SetMockSubmissionOnFork(mock *github.MockClientMockRecord
 		return err
 	}
 
+	mock.GetRepository(gomock.Any(), sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent), Fork: gh.Bool(true)}, nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
+	mock.GetSHA(gomock.Any(), sub.Parent, "heads/master").Return(sub.BaseSHA, nil)
+	mock.GetSHA(gomock.Any(), sub.Fork, "heads/master").Return(resolvedSHA, nil)
 	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(parent)}}, nil)
 	mock.GetSHA(gomock.Any(), sub.Fork, "heads/master").Return(resolvedSHA, nil)
 	mock.GetSHA(gomock.Any(), sub.Fork, "heads/master").Return(resolvedSHA, nil)
@@ -97,30 +101,40 @@ func (qc *QueueClient) SetMockSubmissionOnFork(mock *github.MockClientMockRecord
 	return nil
 }
 
-// SetMockSubmissionSuccess creates all the mock tooling necessary to set up a submission
-func (qc *QueueClient) SetMockSubmissionSuccess(mock *github.MockClientMockRecorder, sub *types.Submission, pathadd string) error {
+// GetYAMLs finds the test yamls needed to run the tests.
+func (qc *QueueClient) GetYAMLs(pathadd string) ([]byte, []byte, error) {
 	repoConfigBytes, err := ioutil.ReadFile(pathadd + "../testdata/standard_repoconfig.yml")
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	taskBytes, err := ioutil.ReadFile(pathadd + "../testdata/standard_task.yml")
 	if err != nil {
+		return nil, nil, err
+	}
+
+	return repoConfigBytes, taskBytes, nil
+}
+
+// SetMockSubmissionSuccess creates all the mock tooling necessary to set up a submission
+func (qc *QueueClient) SetMockSubmissionSuccess(mock *github.MockClientMockRecorder, sub *types.Submission, forkBranch string, pathadd string) error {
+	repoConfigBytes, taskBytes, err := qc.GetYAMLs(pathadd)
+	if err != nil {
 		return err
 	}
 
-	if sub.Parent == "" {
-		sub.Parent = sub.Fork
-	}
-
-	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(sub.Parent)}}, nil)
 	mock.GetRepository(gomock.Any(), sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
 	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(sub.Parent)}}, nil)
-	mock.GetRefs(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"heads/fork-branch"}, nil)
+	mock.GetSHA(gomock.Any(), sub.Fork, forkBranch).Return(sub.HeadSHA, nil) // also here
+	mock.GetSHA(gomock.Any(), sub.Parent, "heads/master").Return(sub.BaseSHA, nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(sub.Parent)}}, nil)
+	mock.GetRefs(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{forkBranch}, nil)
 	mock.GetRefs(gomock.Any(), sub.Parent, sub.BaseSHA).Return([]string{"heads/master"}, nil)
+	mock.GetRefs(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{forkBranch}, nil)
 	mock.GetDiffFiles(gomock.Any(), sub.Parent, sub.BaseSHA, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar"}, nil)
 	mock.GetFileList(gomock.Any(), sub.Fork, sub.HeadSHA).Return([]string{"task.yml", "foo/task.yml", "foo/bar", "bar/task.yml", "bar/quux"}, nil)
 	mock.GetRepository(gomock.Any(), sub.Parent).Return(&gh.Repository{FullName: gh.String(sub.Parent)}, nil)
+	mock.GetRepository(gomock.Any(), sub.Fork).Return(&gh.Repository{FullName: gh.String(sub.Fork), Fork: gh.Bool(true), Parent: &gh.Repository{FullName: gh.String(sub.Parent)}}, nil)
 	mock.GetFile(gomock.Any(), sub.Parent, "refs/heads/master", "tinyci.yml").Return(repoConfigBytes, nil)
 
 	mock.GetFile(gomock.Any(), sub.Fork, sub.HeadSHA, "bar/task.yml").Return(taskBytes, nil)


### PR DESCRIPTION
Right now the solution is to hardcode `heads/master` in a few spots
which was inadequate.

Luckily for us, github renamed the API too (to something more
inclusive), default_branch instead of master_branch contains the default
branch in the API responses now.

I also took the time to clean up some very ugly submission logic.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>
