### PR TITLE
Makefile: hook the stop-demo task into demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ dist: build
 release: distclean dist
 	VERSION="$(VERSION)" box -t "tinyci/release:$(VERSION)" $(RELEASE_BOXFILE)
 
-demo: build-demo-image
+demo: stop-demo build-demo-image
 	docker-compose up
 
 stop-demo:


### PR DESCRIPTION
So resources are automatically cleaned up before starting a new demo
instance. Was causing trouble.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>