### PR TITLE
`tinyci launch`: Multi-launch in single binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ wait:
 
 golangci-lint:
 	go get github.com/golangci/golangci-lint/...
-	golangci-lint run
+	golangci-lint run -v
 
 gen: mockgen
 	cd ci-gen && make gen	

--- a/Makefile
+++ b/Makefile
@@ -164,14 +164,8 @@ start-services: check-service-config
 	pkill tinyci || :
 	go install -v ./cmd/...
 	@if [ "x${START_SERVICES}" != "x" ]; then make start-selective-services; exit 0; fi
-	tinyci service logsvc &
-	tinyci service assetsvc &
-	tinyci service datasvc &
-	tinyci service github-authsvc &
-	tinyci service queuesvc &
-	tinyci service uisvc &
 	tinyci -c .config/hooksvc.yaml service hooksvc &
-	make wait
+	tinyci launch
 
 wait:
 	sleep infinity

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
+	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
 	golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	google.golang.org/appengine v1.6.6 // indirect


### PR DESCRIPTION
This now works as a single command:

`tinyci launch`

and runs the entire suite.

Only postgres and the UI are required to operate the CI after launching
this command, but the hooksvc is still launched independently. This will
be fixed soon.
