### PR TITLE
Boot runner in container

### DIFF
--- a/.config/Caddyfile
+++ b/.config/Caddyfile
@@ -1,6 +1,5 @@
 :3000 {
-  route /hook/* {
-    uri strip_prefix /hook
+  route /hook {
     reverse_proxy localhost:2020
   }
 

--- a/.config/runner.yaml
+++ b/.config/runner.yaml
@@ -1,0 +1,10 @@
+---
+clients:
+  assetsvc: tinyci:6002
+  logsvc: tinyci:6005
+  queuesvc: tinyci:6001
+queue: default
+hostname: tinyci-runner-1
+git:
+  base_repo_path: /var/db/git
+overlay_tempdir: /var/db/overlay

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /.ca
 /.db
 /.logs
+/.runner
+/.overlay
 *.gz
 /build
 \#*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,14 @@ services:
       - jaeger
     external_links:
       - react
+  runner:
+    network_mode: "bridge"
+    privileged: true
+    image: tinyci/runners:latest
+    command: "/usr/local/bin/overlay-runner -c /runner.yaml"
+    volumes:
+      - "./.config/runner.yaml:/runner.yaml"
+      - "./.runner:/var/db/git:shared,rw"
+      - "./.runner-overlay:/var/db/overlay:shared,rw"
+    links:
+      - tinyci


### PR DESCRIPTION
This enables the `make demo` task and associated `docker-compose` tooling to run the overlay runner alongside the other services so that testing can occur.