### PR TITLE
Focus on logging

### DIFF
--- a/api/handlers/grpc/handler.go
+++ b/api/handlers/grpc/handler.go
@@ -74,7 +74,7 @@ func (h *H) logUnaryInterceptor(ctx context.Context, req interface{}, info *grpc
 				"uuid":       u.String(),
 				"finishedAt": fmt.Sprintf("%v", time.Now()),
 				"duration":   fmt.Sprintf("%v", time.Since(started)),
-			}).Info(ctx, "")
+			}).Debug(ctx, "")
 		}
 
 		return res, err
@@ -87,22 +87,22 @@ func (h *H) logStreamInterceptor(srv interface{}, ss grpc.ServerStream, info *gr
 	if h.Service.Clients.Log != nil {
 		u := uuid.New()
 		started := time.Now()
-		h.Service.Clients.Log.WithFields(log.FieldMap{
+		go h.Service.Clients.Log.WithFields(log.FieldMap{
 			"method":    path.Base(info.FullMethod),
 			"service":   h.Service.Name,
 			"uuid":      u.String(),
 			"startedAt": fmt.Sprintf("%v", started),
-		}).Info(ss.Context(), "")
+		}).Debug(ss.Context(), "")
 
 		err := handler(srv, ss)
 
-		h.Service.Clients.Log.WithFields(log.FieldMap{
+		go h.Service.Clients.Log.WithFields(log.FieldMap{
 			"method":     path.Base(info.FullMethod),
 			"service":    h.Service.Name,
 			"uuid":       u.String(),
 			"finishedAt": fmt.Sprintf("%v", time.Now()),
 			"duration":   fmt.Sprintf("%v", time.Since(started)),
-		}).Info(ss.Context(), "")
+		}).Debug(ss.Context(), "")
 
 		return err
 	}

--- a/api/services/grpc/datasvc/setup_test.go
+++ b/api/services/grpc/datasvc/setup_test.go
@@ -36,7 +36,7 @@ func (ds *datasvcSuite) SetUpTest(c *check.C) {
 
 	ds.model = ds.dataServer.Model
 
-	ds.logServer, ds.logDoneChan, _, err = logsvc.MakeLogServer()
+	ds.logServer, _, ds.logDoneChan, _, err = logsvc.MakeLogServer()
 	c.Assert(err, check.IsNil)
 
 	ds.client, err = testclients.NewDataClient()

--- a/api/services/grpc/logsvc/server.go
+++ b/api/services/grpc/logsvc/server.go
@@ -2,20 +2,24 @@ package logsvc
 
 import "github.com/sirupsen/logrus"
 
-func init() {
-	logrus.SetLevel(logrus.DebugLevel)
-}
-
 // LogServer is the handle into the logging grpc service
 type LogServer struct {
 	DispatchTable DispatchTable
+	Level         logrus.Level
 }
 
 // New creates a new LogServer.
-func New(table DispatchTable) *LogServer {
+func New(table DispatchTable, level logrus.Level) *LogServer {
 	if table == nil {
 		table = logLevelDispatch
 	}
 
-	return &LogServer{DispatchTable: table}
+	logrus.SetLevel(level)
+
+	return &LogServer{DispatchTable: table, Level: level}
+}
+
+func (ls *LogServer) changeLevel(level logrus.Level) {
+	logrus.SetLevel(level)
+	ls.Level = level
 }

--- a/api/services/grpc/logsvc/setup_test.go
+++ b/api/services/grpc/logsvc/setup_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 type logsvcSuite struct {
+	service        *LogServer
 	logsvcHandler  *grpcHandler.H
 	logsvcDoneChan chan struct{}
 	journal        *LogJournal
@@ -24,7 +25,7 @@ func TestLogSvc(t *testing.T) {
 
 func (ls *logsvcSuite) SetUpTest(c *check.C) {
 	var err error
-	ls.logsvcHandler, ls.logsvcDoneChan, ls.journal, err = MakeLogServer()
+	ls.logsvcHandler, ls.service, ls.logsvcDoneChan, ls.journal, err = MakeLogServer()
 	c.Assert(err, check.IsNil)
 
 	c.Assert(client.ConfigureRemote(config.DefaultServices.Log.String(), nil, false), check.IsNil)

--- a/api/services/grpc/queuesvc/setup_test.go
+++ b/api/services/grpc/queuesvc/setup_test.go
@@ -45,7 +45,7 @@ func (qs *queuesvcSuite) SetUpTest(c *check.C) {
 
 	var lj *logsvc.LogJournal
 
-	qs.logHandler, qs.logDoneChan, lj, err = logsvc.MakeLogServer()
+	qs.logHandler, _, qs.logDoneChan, lj, err = logsvc.MakeLogServer()
 	c.Assert(err, check.IsNil)
 
 	go lj.Tail()

--- a/api/services/openapi/uisvc/setup_test.go
+++ b/api/services/openapi/uisvc/setup_test.go
@@ -59,7 +59,7 @@ func (us *uisvcSuite) SetUpTest(c *check.C) {
 	us.assetHandler, us.assetDoneChan, err = assetsvc.MakeAssetServer()
 	c.Assert(err, check.IsNil)
 
-	us.logHandler, us.logDoneChan, us.logJournal, err = logsvc.MakeLogServer()
+	us.logHandler, _, us.logDoneChan, us.logJournal, err = logsvc.MakeLogServer()
 	c.Assert(err, check.IsNil)
 
 	go us.logJournal.Tail()

--- a/clients/log/log.go
+++ b/clients/log/log.go
@@ -244,9 +244,9 @@ func (sub *SubLogger) Logf(ctx context.Context, level string, msg string, values
 			localLog(made.String())
 			return
 		}
+	} else {
+		localLog(msg, values...)
 	}
-
-	localLog(msg, values...)
 }
 
 // Log logs a thing
@@ -258,9 +258,9 @@ func (sub *SubLogger) Log(ctx context.Context, level string, msg interface{}, lo
 			localLog(made.String())
 			return
 		}
+	} else {
+		localLog(msg)
 	}
-
-	localLog(msg)
 }
 
 // Info prints an info message

--- a/cmd/tinyci/servers.go
+++ b/cmd/tinyci/servers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/sirupsen/logrus"
 	grpcHandler "github.com/tinyci/ci-agents/api/handlers/grpc"
 	"github.com/tinyci/ci-agents/api/services/grpc/assetsvc"
 	"github.com/tinyci/ci-agents/api/services/grpc/auth/github"
@@ -61,7 +62,15 @@ var servers = []*cmdlib.GRPCServer{
 		Description:    "Centralized logging for tinyCI",
 		DefaultService: config.DefaultServices.Log,
 		RegisterService: func(s *grpc.Server, h *grpcHandler.H) error {
-			log.RegisterLogServer(s, logsvc.New(nil))
+			loglevel := logrus.InfoLevel
+			if h.UserConfig.LogLevel != "" {
+				var err error
+				loglevel, err = logrus.ParseLevel(h.UserConfig.LogLevel)
+				if err != nil {
+					return err
+				}
+			}
+			log.RegisterLogServer(s, logsvc.New(nil, loglevel))
 			return nil
 		},
 		NoLogging: true,

--- a/config/service.go
+++ b/config/service.go
@@ -40,6 +40,7 @@ type UserConfig struct {
 	ServiceConfig ServiceConfig `yaml:"services"`
 	ClientConfig  ClientConfig  `yaml:"clients"`
 
+	LogLevel       string      `yaml:"log_level"`
 	OAuth          OAuthConfig `yaml:"oauth"`
 	Auth           AuthConfig  `yaml:"auth"`
 	HookURL        string      `yaml:"hook_url"`


### PR DESCRIPTION
This fixes the following issues:

- logging level was not selectable
- in many instances, logs would be shipped twice; once on the service,
  once to the remote
- logging filtering was not working properly

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>