### PR TITLE
Fix test races, db close issues

### DIFF
--- a/api/services/grpc/datasvc/setup_test.go
+++ b/api/services/grpc/datasvc/setup_test.go
@@ -15,7 +15,7 @@ import (
 type datasvcSuite struct {
 	model        *db.Model
 	dataDoneChan chan struct{}
-	dataServer   *grpcHandler.H
+	dataServer   *DataServer
 	logDoneChan  chan struct{}
 	logServer    *grpcHandler.H
 	client       *testclients.DataClient
@@ -34,7 +34,7 @@ func (ds *datasvcSuite) SetUpTest(c *check.C) {
 	ds.dataServer, ds.dataDoneChan, err = MakeDataServer()
 	c.Assert(err, check.IsNil)
 
-	ds.model = ds.dataServer.Model
+	ds.model = ds.dataServer.H.Model
 
 	ds.logServer, _, ds.logDoneChan, _, err = logsvc.MakeLogServer()
 	c.Assert(err, check.IsNil)
@@ -46,5 +46,7 @@ func (ds *datasvcSuite) SetUpTest(c *check.C) {
 func (ds *datasvcSuite) TearDownTest(c *check.C) {
 	close(ds.logDoneChan)
 	close(ds.dataDoneChan)
+	ds.model.GetDB().Close()
+	ds.dataServer.C.Close()
 	time.Sleep(100 * time.Millisecond)
 }

--- a/api/services/grpc/datasvc/testserver.go
+++ b/api/services/grpc/datasvc/testserver.go
@@ -13,7 +13,7 @@ import (
 
 // MakeDataServer makes an instance of the datasvc on port 6000. It returns a
 // chan which can be closed to terminate it, and any boot-time errors.
-func MakeDataServer() (*grpcHandler.H, chan struct{}, error) {
+func MakeDataServer() (*DataServer, chan struct{}, error) {
 	h := &grpcHandler.H{
 		Service: config.Service{
 			UseDB: true,
@@ -39,11 +39,12 @@ func MakeDataServer() (*grpcHandler.H, chan struct{}, error) {
 
 	db, err := db.NewConn(h.UserConfig.DSN)
 	if err != nil {
-		return h, nil, err
+		return nil, nil, err
 	}
 
-	data.RegisterDataServer(srv, &DataServer{H: h, C: protoconv.New(db)})
+	ds := &DataServer{H: h, C: protoconv.New(db)}
+	data.RegisterDataServer(srv, ds)
 
 	doneChan, err := h.Boot(t, srv, make(chan struct{}))
-	return h, doneChan, err
+	return ds, doneChan, err
 }

--- a/api/services/grpc/queuesvc/setup_test.go
+++ b/api/services/grpc/queuesvc/setup_test.go
@@ -22,7 +22,7 @@ type queuesvcSuite struct {
 	dataDoneChan   chan struct{}
 	logDoneChan    chan struct{}
 	model          *db.Model
-	dataHandler    *grpcHandler.H
+	dataHandler    *datasvc.DataServer
 	logHandler     *grpcHandler.H
 	queueHandler   *grpcHandler.H
 }

--- a/api/services/openapi/uisvc/basic_test.go
+++ b/api/services/openapi/uisvc/basic_test.go
@@ -190,7 +190,7 @@ func (us *uisvcSuite) TestSubmit(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	for i := 0; i < len(runs); i++ {
-		client.EXPECT().ErrorStatus(
+		erikhClient.EXPECT().ErrorStatus(
 			gomock.Any(),
 			"erikh",
 			"parent",

--- a/api/services/openapi/uisvc/setup_test.go
+++ b/api/services/openapi/uisvc/setup_test.go
@@ -33,7 +33,7 @@ type uisvcSuite struct {
 	dataDoneChan  chan struct{}
 	assetDoneChan chan struct{}
 	logHandler    *grpcHandler.H
-	dataHandler   *grpcHandler.H
+	dataHandler   *datasvc.DataServer
 	queueHandler  *grpcHandler.H
 	assetHandler  *grpcHandler.H
 
@@ -79,6 +79,11 @@ func (us *uisvcSuite) TearDownTest(c *check.C) {
 	close(us.queueDoneChan)
 	close(us.logDoneChan)
 	close(us.assetDoneChan)
+	us.datasvcClient.Client().Close()
+	us.queuesvcClient.Client().Close()
+	us.dataHandler.H.Model.GetDB().Close()
+	us.dataHandler.C.Close()
+	us.logJournal.Reset()
 	time.Sleep(100 * time.Millisecond)
 }
 

--- a/db/protoconv/map.go
+++ b/db/protoconv/map.go
@@ -53,6 +53,10 @@ func New(db *sql.DB) *Converter {
 	return c
 }
 
+func (c *Converter) Close() error {
+	return c.db.Close()
+}
+
 func (c *Converter) registerConversion(direction int, i interface{}, fun conversionFunc) {
 	if c.converters[direction] == nil {
 		c.converters[direction] = reflectMap{}


### PR DESCRIPTION
This fixes:

- Data races in uisvc tests
- DB close issues
- Improper use of mock github client in a few situations.

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>